### PR TITLE
using superdesk-planning 1.5

### DIFF
--- a/client/package.json
+++ b/client/package.json
@@ -4,6 +4,6 @@
     "dependencies": {
         "superdesk-analytics": "superdesk/superdesk-analytics#master",
         "superdesk-core": "1.29.0",
-        "superdesk-planning": "superdesk/superdesk-planning#master"
+        "superdesk-planning": "superdesk/superdesk-planning#1.5"
     }
 }


### PR DESCRIPTION
superdesk-client-core doesn't seem to be working with master of
superdesk-planning, so this patch restrict its version to 1.5