### PR TITLE
Update mongo install instruction on MacOS

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,11 @@ These services must be installed, configured and running:
  * Python (>= 3.5)
  * Node.js (with `npm`)
 
-On macOS, if you have [homebrew](https://brew.sh/) installed, simply run: `brew install mongodb elasticsearch@2.4 redis python3 node`.
+On macOS, if you have [homebrew](https://brew.sh/) installed, simply run: 
+```sh
+brew tap mongodb/brew
+brew install mongodb-community elasticsearch@2.4 redis python3 node
+```
 
 ### Installation steps:
 


### PR DESCRIPTION
Homebrew has removed mongo from its core formulas
`https://github.com/Homebrew/homebrew-core/pull/43770`
