### PR TITLE
[MACROS] added a `macros` directory + created set_default_metadata and set_default_metadata_with_translate

### DIFF
--- a/server/belga/macros/__init__.py
+++ b/server/belga/macros/__init__.py
@@ -1,0 +1,16 @@
+# -*- coding: utf-8; -*-
+#
+# This file is part of Superdesk.
+#
+# Copyright 2019 Sourcefabric z.u. and contributors.
+#
+# For the full copyright and license information, please see the
+# AUTHORS and LICENSE files distributed with this source code, or
+# at https://www.sourcefabric.org/superdesk/license
+
+import os.path
+from superdesk.macros import load_macros
+
+
+macros_folder = os.path.realpath(os.path.dirname(__file__))
+load_macros(macros_folder, package_prefix="belga.macros")

--- a/server/belga/macros/set_default_metadata.py
+++ b/server/belga/macros/set_default_metadata.py
@@ -1,0 +1,83 @@
+# -*- coding: utf-8; -*-
+#
+# This file is part of Superdesk.
+#
+# Copyright 2013, 2014 Sourcefabric z.u. and contributors.
+#
+# For the full copyright and license information, please see the
+# AUTHORS and LICENSE files distributed with this source code, or
+# at https://www.sourcefabric.org/superdesk/license
+import logging
+from superdesk import get_resource_service
+
+
+logger = logging.getLogger(__name__)
+SUBJECT_SCHEMES = ('news_services', 'news_products', 'distribution')
+
+
+def get_default_content_template(item, **kwargs):
+    if 'dest_desk_id' in kwargs:
+        desk_id = kwargs['dest_desk_id']
+    elif 'task' in item and 'desk' in item['task']:
+        desk_id = item['task'].get('desk')
+    else:
+        logger.warning("Can't set default data, no desk identifier found")
+        return
+
+    desk = get_resource_service('desks').find_one(req=None, _id=desk_id)
+    if not desk:
+        logger.warning('Can\'t find desk with id "{desk_id}"'.format(desk_id=desk_id))
+        return
+
+    content_template_id = desk.get("default_content_template")
+    if not content_template_id:
+        logger.warning("No default content template set for {desk_name}".format(
+            desk_name=desk.get('name', desk_id)))
+        return
+    content_template = get_resource_service("content_templates").find_one(req=None, _id=content_template_id)
+    if not content_template:
+        logger.warning('Can\'t find content_template with id "{content_template_id}"'.format(
+            content_template_id=content_template_id))
+        return
+
+    return content_template
+
+
+def set_default_metadata(item, **kwargs):
+    """Replace some metadata from default content template
+
+    The following metadata: ``News Services``, ``News Products``, ``Language``,
+    ``Distribution``, and ``Storytags (keywords)`` will be replaced (or created if they
+    don't already exist) by the value set in desk's default content template
+    """
+    content_template = get_default_content_template(item, **kwargs)
+    if not content_template:
+        return
+
+    data = content_template['data']
+
+    item['language'] = data.get('language')
+    item['keywords'] = data.get('keywords')
+
+    # subject contains remaining metadata to copy
+    subject = item.setdefault('subject', [])
+
+    # we first remove conflicting metadata, if any
+    to_delete = []
+    for item in subject:
+        if item.get('scheme') in SUBJECT_SCHEMES:
+            to_delete.append(item)
+    for item in to_delete:
+        subject.remove(item)
+
+    # and now we add the new one
+    subject.extend([i for i in data.get('subject', []) if i.get('scheme') in SUBJECT_SCHEMES])
+
+    return item
+
+
+name = 'Set Default Metadata'
+label = name
+callback = set_default_metadata
+access_type = 'backend'
+action_type = 'direct'

--- a/server/belga/macros/set_default_metadata_with_translate.py
+++ b/server/belga/macros/set_default_metadata_with_translate.py
@@ -1,0 +1,69 @@
+# -*- coding: utf-8; -*-
+#
+# This file is part of Superdesk.
+#
+# Copyright 2013, 2014 Sourcefabric z.u. and contributors.
+#
+# For the full copyright and license information, please see the
+# AUTHORS and LICENSE files distributed with this source code, or
+# at https://www.sourcefabric.org/superdesk/license
+import logging
+from .set_default_metadata import get_default_content_template, set_default_metadata
+from superdesk import get_resource_service
+from superdesk.errors import StopDuplication
+from copy import deepcopy
+
+
+logger = logging.getLogger(__name__)
+
+
+def set_default_metadata_with_translate(item, **kwargs):
+    """Replace some metadata from default content template and set translation id
+
+    This macro is the same as "Set Default Metadata" + adding a translation
+    link to original item.
+    """
+    archive_service = get_resource_service('archive')
+    move_service = get_resource_service('move')
+    original_item = archive_service.find_one(None, _id=item['_id'])
+
+    desk_id = kwargs.get('dest_desk_id')
+    if not desk_id:
+        logger.warning("no destination id specified")
+        return
+    stage_id = kwargs.get('dest_stage_id')
+    if not stage_id:
+        logger.warning("no stage id specified")
+        return
+
+    # we first do the translation, we need destination language for that
+    content_template = get_default_content_template(item, **kwargs)
+    language = content_template['data'].get('language')
+    if not language:
+        logger.warning("no language set in default content template")
+        return
+
+    new_item = deepcopy(original_item)
+    new_item['language'] = language
+
+    translate_service = get_resource_service('translate')
+    new_id = translate_service.create([new_item])[0]
+
+    # translation is done, we now move the item to the new desk
+    dest = {"task": {"desk": desk_id, "stage": stage_id}}
+    move_service.move_content(new_id, dest)
+
+    # and now we apply the update
+    new_item = archive_service.find_one(req=None, _id=new_id)
+    set_default_metadata(new_item, **kwargs)
+    archive_service.put(new_id, new_item)
+
+    # no need for further treatment, we stop here internal_destinations workflow
+    raise StopDuplication
+
+
+name = 'Set Default Metadata With Translate'
+label = name
+callback = set_default_metadata_with_translate
+access_type = 'frontend'
+action_type = 'direct'

--- a/server/settings.py
+++ b/server/settings.py
@@ -25,7 +25,8 @@ INSTALLED_APPS.extend([
     'belga.search_providers',
     'belga.io',
     'belga.command',
-    'belga.publish'
+    'belga.publish',
+    'belga.macros',
 ])
 
 SECRET_KEY = env('SECRET_KEY', '')


### PR DESCRIPTION
A new `macros` directory is now available, and macros there are
automatically loaded on startup.

The `set_default_metadata` copied some metadata from desk's default
content template as requested in SDBELGA-142.

The `set_default_metadata_with_translate` do call `set_default_metadata`
then translate the item to the dest desk default content template
language and move it.

SDBELGA-142 and SDBELGA-143
