### PR TITLE
Update metadata for inject

### DIFF
--- a/server/belga/io/feed_parsers/base_belga_newsml_1_2.py
+++ b/server/belga/io/feed_parsers/base_belga_newsml_1_2.py
@@ -74,10 +74,12 @@ class BaseBelgaNewsMLOneFeedParser(NewsMLOneFeedParser):
                     if not [it for it in item.get('subject', []) if it.get('scheme') == 'news_products']:
                         product = {"name": 'GENERAL', "qcode": 'GENERAL', "scheme": "news_products"}
                         item.setdefault('subject', []).append(product)
-                    item['subject'].extend([
+                    item.setdefault('subject', []).extend([
                         {"name": 'default', "qcode": 'default', "scheme": "distribution"},  # Distribution is default
                         {"name": 'NEWS', "qcode": 'NEWS', "scheme": "news_services"},  # add service is NEW
                     ])
+                    # delete subject is duplicated
+                    item['subject'] = [dict(t) for t in {tuple(d.items()) for d in item['subject']}]
                     item = self.populate_fields(item)
                 except SkipItemException:
                     continue

--- a/server/belga/io/feed_parsers/base_belga_newsml_1_2.py
+++ b/server/belga/io/feed_parsers/base_belga_newsml_1_2.py
@@ -76,8 +76,7 @@ class BaseBelgaNewsMLOneFeedParser(NewsMLOneFeedParser):
                         item.setdefault('subject', []).append(product)
                     item['subject'].extend([
                         {"name": 'default', "qcode": 'default', "scheme": "distribution"},  # Distribution is default
-                        {"name": 'NEWS', "qcode": 'NEWS', "scheme": "news_services"}  # add service is NEW
-                        
+                        {"name": 'NEWS', "qcode": 'NEWS', "scheme": "news_services"},  # add service is NEW
                     ])
                     item = self.populate_fields(item)
                 except SkipItemException:

--- a/server/belga/io/feed_parsers/base_belga_newsml_1_2.py
+++ b/server/belga/io/feed_parsers/base_belga_newsml_1_2.py
@@ -74,9 +74,11 @@ class BaseBelgaNewsMLOneFeedParser(NewsMLOneFeedParser):
                     if not [it for it in item.get('subject', []) if it.get('scheme') == 'news_products']:
                         product = {"name": 'GENERAL', "qcode": 'GENERAL', "scheme": "news_products"}
                         item.setdefault('subject', []).append(product)
-                    # add service is NEW
-                    service = {"name": 'NEWS', "qcode": 'NEWS', "scheme": "news_services"}
-                    item.setdefault('subject', []).append(service)
+                    item['subject'].extend([
+                        {"name": 'default', "qcode": 'default', "scheme": "distribution"},  # Distribution is default
+                        {"name": 'NEWS', "qcode": 'NEWS', "scheme": "news_services"}  # add service is NEW
+                        
+                    ])
                     item = self.populate_fields(item)
                 except SkipItemException:
                     continue

--- a/server/belga/io/feed_parsers/base_belga_newsml_1_2.py
+++ b/server/belga/io/feed_parsers/base_belga_newsml_1_2.py
@@ -417,7 +417,6 @@ class BaseBelgaNewsMLOneFeedParser(NewsMLOneFeedParser):
             element = newslines_el.find('KeywordLine')
             if element is not None:
                 item['keyword_line'] = element.text
-                # ANP
 
         admin_el = component_el.find('AdministrativeMetadata')
         if admin_el is not None:

--- a/server/belga/io/feed_parsers/belga_afp_newsml_1_2.py
+++ b/server/belga/io/feed_parsers/belga_afp_newsml_1_2.py
@@ -33,7 +33,7 @@ class BelgaAFPNewsMLOneFeedParser(BaseBelgaNewsMLOneFeedParser):
 
     def parser_newsitem(self, item, newsitem_el):
         super().parser_newsitem(item, newsitem_el)
-        # mapping product from keyword, and have only one product
+        # mapping product from category, and have only one product
         product = {}
         for category in item.get('anpa_category', []):
             qcode = self.MAPPING_CATEGORY.get(category.get('qcode'))

--- a/server/belga/io/feed_parsers/belga_afp_newsml_1_2.py
+++ b/server/belga/io/feed_parsers/belga_afp_newsml_1_2.py
@@ -37,7 +37,7 @@ class BelgaAFPNewsMLOneFeedParser(BaseBelgaNewsMLOneFeedParser):
         for keyword in item.get('keywords', []):
             keyword = unicodedata.normalize('NFKD', keyword.strip(
                 '/').upper()).encode('ascii', 'ignore').decode('utf-8')
-            product_codes = [k for k, v in self.MAPPING_KEYWORDS.items() for it in v if keyword in it]
+            product_codes = [k for k, v in self.MAPPING_KEYWORDS.items() for key in v if key in keyword]
             if product_codes:
                 product = {
                     "name": product_codes[0],
@@ -53,6 +53,11 @@ class BelgaAFPNewsMLOneFeedParser(BaseBelgaNewsMLOneFeedParser):
             first_line = etree.fromstring(first_line).text
             headline = 'URGENT: ' + first_line.strip()
             item['headline'] = headline
+
+        # label must be empty
+        item['subject'] = [i for i in item['subject'] if i.get('scheme') != 'label']
+        item['credits'] = 'AFP'
+        item['distribution'] = 'default'
         return item
 
 

--- a/server/belga/io/feed_parsers/belga_anp_newsml_1_2.py
+++ b/server/belga/io/feed_parsers/belga_anp_newsml_1_2.py
@@ -41,6 +41,8 @@ class BelgaANPNewsMLOneFeedParser(BaseBelgaNewsMLOneFeedParser):
                 product = {'name': qcode, 'qcode': qcode, 'scheme': 'news_products'} if qcode else None
                 item.setdefault('subject', []).append(product)
                 break
+            item['credits'] = 'ANP'
+            item['distribution'] = 'default'
         return item
 
 

--- a/server/belga/io/feed_parsers/belga_anp_newsml_1_2.py
+++ b/server/belga/io/feed_parsers/belga_anp_newsml_1_2.py
@@ -41,8 +41,9 @@ class BelgaANPNewsMLOneFeedParser(BaseBelgaNewsMLOneFeedParser):
                 product = {'name': qcode, 'qcode': qcode, 'scheme': 'news_products'} if qcode else None
                 item.setdefault('subject', []).append(product)
                 break
-            item['credits'] = 'ANP'
-            item['distribution'] = 'default'
+        # Credits is ANP
+        credit = {"name": 'ANP', "qcode": 'ANP', "scheme": "credits"}
+        item.setdefault('subject', []).append(credit)
         return item
 
 

--- a/server/belga/io/feed_parsers/belga_anpa.py
+++ b/server/belga/io/feed_parsers/belga_anpa.py
@@ -61,6 +61,7 @@ class BelgaANPAFeedParser(ANPAFeedParser):
                 b'([0-9]{1,2})-([0-9]{1,2}) ([0-9]{4})',
                 lines[1], flags=re.I)
             if m:
+                item['language'] = 'en'
                 item['priority'] = 2 if m.group(1).decode() == 'u' else 3
                 qcode = m.group(2).decode().upper()
                 item['anpa_category'] = [{'qcode': qcode}]

--- a/server/belga/io/feed_parsers/belga_ats_newsml_1_2.py
+++ b/server/belga/io/feed_parsers/belga_ats_newsml_1_2.py
@@ -39,6 +39,9 @@ class BelgaATSNewsMLOneFeedParser(BaseBelgaNewsMLOneFeedParser):
         super().parser_newsmanagement(item, manage_el)
         item['firstcreated'] = item['firstcreated'].astimezone(pytz.utc)
         item['versioncreated'] = item['versioncreated'].astimezone(pytz.utc)
+        # Credits is AFP
+        credit = {"name": 'ATS', "qcode": 'ATS', "scheme": "credits"}
+        item.setdefault('subject', []).append(credit)
 
     def parser_newscomponent(self, item, newscomponent_el):
         """

--- a/server/belga/io/feed_parsers/belga_efe_newsml_1_2.py
+++ b/server/belga/io/feed_parsers/belga_efe_newsml_1_2.py
@@ -30,7 +30,8 @@ class BelgaEFENewsMLOneFeedParser(BaseBelgaNewsMLOneFeedParser):
         super().parser_contentitem(item, content_el)
         categoria = content_el.find('DataContent/nitf/head/meta[@name="categoria"]')
         if categoria is not None:
-            qcode = categoria.attrib.get('content').upper() if categoria is not None else None
+            content = categoria.attrib.get('content')
+            qcode = content.upper() if content is not None else None
             if qcode:
                 item.setdefault('anpa_category', []).append({'qcode': qcode})
                 qcode = self.MAPPING_PRODUCTS.get(qcode)

--- a/server/belga/io/feed_parsers/belga_efe_newsml_1_2.py
+++ b/server/belga/io/feed_parsers/belga_efe_newsml_1_2.py
@@ -36,6 +36,9 @@ class BelgaEFENewsMLOneFeedParser(BaseBelgaNewsMLOneFeedParser):
                 item.setdefault('anpa_category', []).append({'qcode': qcode})
                 qcode = self.MAPPING_PRODUCTS.get(qcode)
                 item.setdefault('subject', []).append({'qcode': qcode, 'name': qcode, 'scheme': 'news_products'})
+        # credit is EFE
+        credit = {"name": 'EFE', "qcode": 'EFE', "scheme": "credits"}
+        item.setdefault('subject', []).append(credit)
         return item
 
 

--- a/server/belga/io/feed_parsers/belga_iptc7901.py
+++ b/server/belga/io/feed_parsers/belga_iptc7901.py
@@ -31,10 +31,10 @@ class BelgaIPTC7901FeedParser(DPAIPTC7901FeedParser):
 
     label = 'Belga IPTC 7901 Parser'
 
-    types = [
-        ('dpa', b'([a-zA-Z]*)([0-9]*) (.) ([A-Z]{1,3}) ([0-9]*) ([a-zA-Z0-9 ]*)', [' =\n']),
-        ('ats', b'(\x7f\x7f|\x7f)', [' = \r\n'])
-    ]
+    types = {
+        'dpa': (b'([a-zA-Z]*)([0-9]*) (.) ([A-Z]{1,3}) ([0-9]*) ([a-zA-Z0-9 ]*)', [' =\n']),
+        'ats': (b'(\x7f\x7f|\x7f)', [' = \r\n']),
+    }
     txt_type = None
 
     MAPPING_PRODUCTS = {
@@ -57,40 +57,49 @@ class BelgaIPTC7901FeedParser(DPAIPTC7901FeedParser):
         try:
             BelgaIPTC7901FeedParser.txt_type = None
             with open(file_path, 'rb') as f:
-                lines = [line for line in f]
-                for item in self.types:
-                    check_type = re.match(item[1], lines[0], flags=re.I)
+                lines = list(f)
+                for _type, regex in self.types.items():
+                    check_type = re.match(regex[0], lines[0], flags=re.I)
                     if check_type:
-                        BelgaIPTC7901FeedParser.txt_type = item
+                        BelgaIPTC7901FeedParser.txt_type = _type
                         return check_type
-
         except Exception:
             return False
 
     def parse(self, file_path, provider=None):
         item = {}
-        if BelgaIPTC7901FeedParser.txt_type[0] == 'dpa':
+        _type = BelgaIPTC7901FeedParser.txt_type
+        if _type == 'dpa':
             item = self.parse_content_dpa(file_path, provider)
-            item = self.dpa_derive_dateline(item)
-            # Markup the text and set the content type
-            item['body_html'] = '<p>' + item['body_html'].replace('\r\n', ' ').replace('\n', '</p><p>') + '</p>'
-            item[ITEM_TYPE] = CONTENT_TYPE.TEXT
-        if BelgaIPTC7901FeedParser.txt_type[0] == 'ats':
+        if _type == 'ats':
             item = self.parse_content_ats(file_path, provider)
-            item = self.dpa_derive_dateline(item)
-            # Markup the text and set the content type
-            item['body_html'] = '<p>' + item['body_html'].replace('\r\n', ' ').replace('\n', '</p><p>') + '</p>'
-            item[ITEM_TYPE] = CONTENT_TYPE.TEXT
+        item = self.dpa_derive_dateline(item)
+        # Markup the text and set the content type
+        item['body_html'] = '<p>' + item['body_html'].replace('\r\n', ' ').replace('\n', '</p><p>') + '</p>'
 
+        invalid_xmlchars = {
+            '&': '&amp;', '<': '&lt;', '>': '&gt;', '\u0007': ' ', '\u0003': ' ', '\u0004': ' ', '\u001f': ' '
+        }
+        for char, replace_char in invalid_xmlchars.items():
+            item['body_html'].replace(char, replace_char)
+            item['headline'].replace(char, replace_char)
+            item.get('lead', '').replace(char, replace_char)
+
+        item[ITEM_TYPE] = CONTENT_TYPE.TEXT
         return item
 
     def parse_content_ats(self, file_path, provider=None):
         try:
-            item = {ITEM_TYPE: CONTENT_TYPE.TEXT, 'guid': generate_guid(type=GUID_TAG),
-                    'versioncreated': utcnow()}
+            item = {
+                ITEM_TYPE: CONTENT_TYPE.TEXT,
+                'guid': generate_guid(type=GUID_TAG),
+                'versioncreated': utcnow(),
+                'language': 'fr',
+            }
 
             with open(file_path, 'rb') as f:
-                lines = [line for line in f]
+                lines = list(f)
+
             # parse first header line
             m = re.match(b'\x7f\x01([a-zA-Z]*)([0-9]*) (.) ([A-Z]{1,3}) ([0-9]*) ([a-zA-Z0-9 ]*)', lines[1], flags=re.I)
             if m:
@@ -101,57 +110,27 @@ class BelgaIPTC7901FeedParser(DPAIPTC7901FeedParser):
                 item['anpa_category'] = [{'qcode': self.map_category(qcode)}]
                 qcode = self.MAPPING_PRODUCTS['ats'].get(qcode, 'GENERAL')
                 item.setdefault('subject', []).append({'qcode': qcode, 'name': qcode, 'scheme': 'news_products'})
-
-                # service is always equal NEWS
-                service = {"name": 'NEWS', "qcode": 'NEWS', "scheme": "news_services"}
-                item.setdefault('subject', []).append(service)
-                # Credits is DPA
-                credit = {"name": 'ATS', "qcode": 'ATS', "scheme": "credits"}
-                item.setdefault('subject', []).append(credit)
-                # Distribution is default
-                dist = {"name": 'default', "qcode": 'default', "scheme": "distribution"}
-                item.setdefault('subject', []).append(dist)
-
+                item['subject'].extend([
+                    {"name": 'NEWS', "qcode": 'NEWS', "scheme": "news_services"},  # service is always NEWS
+                    {"name": 'ATS', "qcode": 'ATS', "scheme": "credits"},
+                    {"name": 'default', "qcode": 'default', "scheme": "distribution"},
+                ])
                 item['word_count'] = int(m.group(5).decode())
 
-            inHeader = False
-            inBody = False
-            line_count = 0
-            item['headline'] = ''
-            item['body_html'] = ''
-            # start check each line for get information
-            for bline in lines[1:]:
-                line = bline.decode('latin-1', 'replace')
-                line_count += 1
+            content = b'\n'.join(lines[1:]).decode('latin-1', 'replace')
+            header = re.search(r'.*=', content)
+            item['headline'] = header.group(0).strip() if header else ''
 
-                # dpa start header when line number is 3
-                if bline[0:1] == b'\x02':
-                    line = line[1:]
-                    inHeader = True
-
-                # dpa end at especially characters
-                if bline[0:1] == b'\x03':
-                    break
-
-                if inHeader is True:
-                    # dpa end header when line end with especially characters (ex '=\r\n')
-                    end_string = self.check_mendwith(line, BelgaIPTC7901FeedParser.txt_type[2])
-                    if end_string:
-                        if line.startswith('By '):
-                            item['byline'] = line.replace('By ', '').rstrip(end_string)
-                        else:
-                            item['headline'] += line.rstrip(end_string)
-                        inHeader = False
-                        # set flag inBody when header is end
-                        inBody = True
-                    else:
-                        item['headline'] += line
-                        inHeader = True
-                    continue
-                # dpa start body when the header is end
-                if inBody:
-                    item['body_html'] += line
-                    continue
+            body = re.search(r'(?s)=\s{2,}(.*)', content)
+            if body:
+                body = re.split(r'(?s)\s{3,}', body.group(1), 1)
+                if len(body) == 2:
+                    item['abstract'], item['body_html'] = body
+                    city = re.search(r'^(\S*)', item['abstract'])
+                    if city:
+                        item.setdefault('extra', {})['city'] = city.group(0).strip()
+                else:
+                    item['body_html'] = body[0]
             return item
         except Exception as ex:
             raise ParserError.IPTC7901ParserError(exception=ex, provider=provider)
@@ -162,7 +141,7 @@ class BelgaIPTC7901FeedParser(DPAIPTC7901FeedParser):
                     'versioncreated': utcnow()}
 
             with open(file_path, 'rb') as f:
-                lines = [line for line in f]
+                lines = list(f)
             # parse first header line
             m = re.match(b'([a-zA-Z]*)([0-9]*) (.) ([A-Z]{1,3}) ([0-9]*) ([a-zA-Z0-9 ]*)', lines[0], flags=re.I)
             if m:
@@ -175,13 +154,13 @@ class BelgaIPTC7901FeedParser(DPAIPTC7901FeedParser):
                 qcode = self.MAPPING_PRODUCTS['dpa'].get(qcode, 'GENERAL')
                 item.setdefault('subject', []).append({'qcode': qcode, 'name': qcode, 'scheme': 'news_products'})
                 # service is always equal NEWS
-                service = {"name": 'NEWS', "qcode": 'NEWS', "scheme": "news_services"}                
+                service = {"name": 'NEWS', "qcode": 'NEWS', "scheme": "news_services"}
                 item.setdefault('subject', []).append(service)
                 # Credits is DPA
                 credit = {"name": 'DPA', "qcode": 'DPA', "scheme": "credits"}
                 item.setdefault('subject', []).append(credit)
                 # Distribution is default
-                dist = {"name": 'default', "qcode": 'default', "scheme": "distribution"}                
+                dist = {"name": 'default', "qcode": 'default', "scheme": "distribution"}
                 item.setdefault('subject', []).append(dist)
                 item['word_count'] = int(m.group(5).decode())
 
@@ -218,7 +197,7 @@ class BelgaIPTC7901FeedParser(DPAIPTC7901FeedParser):
                             item['anpa_header'] = line
                         continue
                     # dpa end header when line end with especially characters (ex '=\r\n')
-                    end_string = self.check_mendwith(line, BelgaIPTC7901FeedParser.txt_type[2])
+                    end_string = self.check_mendwith(line, self.types[BelgaIPTC7901FeedParser.txt_type][1])
                     if end_string:
                         if line.startswith('By '):
                             item['byline'] = line.replace('By ', '').rstrip(end_string)
@@ -260,7 +239,10 @@ class BelgaIPTC7901FeedParser(DPAIPTC7901FeedParser):
         :return:
         """
         item['headline'] = ''
-        headers, divider, the_rest = self.mpartition(item.get('body_html', ''), BelgaIPTC7901FeedParser.txt_type[2])
+        headers, divider, the_rest = self.mpartition(
+            item.get('body_html', ''),
+            self.types[BelgaIPTC7901FeedParser.txt_type][1]
+        )
         # If no divider then there was only one line and that is the headline so clean up the stray '='
         if not divider:
             item['headline'] = item.get('headline').replace(' =', '')

--- a/server/belga/io/feed_parsers/belga_iptc7901.py
+++ b/server/belga/io/feed_parsers/belga_iptc7901.py
@@ -105,6 +105,12 @@ class BelgaIPTC7901FeedParser(DPAIPTC7901FeedParser):
                 # service is always equal NEWS
                 service = {"name": 'NEWS', "qcode": 'NEWS', "scheme": "news_services"}
                 item.setdefault('subject', []).append(service)
+                # Credits is DPA
+                credit = {"name": 'ATS', "qcode": 'ATS', "scheme": "credits"}
+                item.setdefault('subject', []).append(credit)
+                # Distribution is default
+                dist = {"name": 'default', "qcode": 'default', "scheme": "distribution"}
+                item.setdefault('subject', []).append(dist)
 
                 item['word_count'] = int(m.group(5).decode())
 
@@ -169,8 +175,14 @@ class BelgaIPTC7901FeedParser(DPAIPTC7901FeedParser):
                 qcode = self.MAPPING_PRODUCTS['dpa'].get(qcode, 'GENERAL')
                 item.setdefault('subject', []).append({'qcode': qcode, 'name': qcode, 'scheme': 'news_products'})
                 # service is always equal NEWS
-                service = {"name": 'NEWS', "qcode": 'NEWS', "scheme": "news_services"}
+                service = {"name": 'NEWS', "qcode": 'NEWS', "scheme": "news_services"}                
                 item.setdefault('subject', []).append(service)
+                # Credits is DPA
+                credit = {"name": 'DPA', "qcode": 'DPA', "scheme": "credits"}
+                item.setdefault('subject', []).append(credit)
+                # Distribution is default
+                dist = {"name": 'default', "qcode": 'default', "scheme": "distribution"}                
+                item.setdefault('subject', []).append(dist)
                 item['word_count'] = int(m.group(5).decode())
 
             inHeader = False

--- a/server/belga/io/feed_parsers/belga_tass_newsml_1_2.py
+++ b/server/belga/io/feed_parsers/belga_tass_newsml_1_2.py
@@ -49,6 +49,8 @@ class BelgaTASSNewsMLOneFeedParser(BaseBelgaNewsMLOneFeedParser):
                     }
                     item.setdefault('subject', []).append(product)
                     break
+        credit = {"name": 'TASS', "qcode": 'TASS', "scheme": "credits"}
+        item['subject'].append(credit)
 
     def parser_newscomponent(self, item, newscomponent_el):
         """

--- a/server/tests/io/feed_parsers/belga_afp_newsml_1_2_test.py
+++ b/server/tests/io/feed_parsers/belga_afp_newsml_1_2_test.py
@@ -35,9 +35,7 @@ class BelgaAFPNewsMLOneTestCase(BelgaTestCase):
     def test_content(self):
         item = self.item[0]
         self.assertEqual(item["ingest_provider_sequence"], "0579")
-        self.assertEqual(item["subject"], [{'name': 'France-procès-assises-drogues-police',
-                                            'qcode': 'France-procès-assises-drogues-police', 'scheme': 'label'},
-                                           {'name': 'News', 'qcode': 'News', 'scheme': 'news_item_types'},
+        self.assertEqual(item["subject"], [{'name': 'News', 'qcode': 'News', 'scheme': 'news_item_types'},
                                            {'qcode': '02001004', 'name': 'drug trafficking',
                                             'scheme': 'iptc_subject_codes'},
                                            {'qcode': '02008000', 'name': 'trials', 'scheme': 'iptc_subject_codes'},
@@ -57,6 +55,8 @@ class BelgaAFPNewsMLOneTestCase(BelgaTestCase):
                                            {'name': 'ECONOMY', 'qcode': 'ECONOMY', 'scheme': 'news_products'},
                                            {'name': 'NEWS', 'qcode': 'NEWS', 'scheme': 'news_services'}])
         self.assertEqual(item["priority"], 4)
+        self.assertEqual(item["credits"], 'AFP')
+        self.assertEqual(item["distribution"], 'default')
         self.assertEqual(item["provider_id"], "afp.com")
         self.assertEqual(item["date_id"], "20190121T104233Z")
         self.assertEqual(item["item_id"], "TX-PAR-RHO61")
@@ -79,7 +79,7 @@ class BelgaAFPNewsMLOneTestCase(BelgaTestCase):
         self.assertEqual(item["anpa_category"], [{'qcode': 'CLJ'}, {'qcode': 'POL'}])
         self.assertEqual(item["extra"], {'how_present': 'Origin', 'country': 'FRA', 'city': 'Paris'})
         self.assertEqual(item["generator_software"], "libg2")
-        self.assertEqual(item["keywords"], ['France', 'procès', 'assises', 'drogues', 'police', 'marches'])
+        self.assertEqual(item["keywords"], ['France', 'procès', 'assises', 'drogues', 'police', 'marches_test'])
         self.assertEqual(item["type"], "text")
         self.assertEqual(item["format"], "NITF3.1")
         self.assertEqual(item["characteristics"], {'size_bytes': '1620', 'word_count': '269'})

--- a/server/tests/io/feed_parsers/belga_afp_newsml_1_2_test.py
+++ b/server/tests/io/feed_parsers/belga_afp_newsml_1_2_test.py
@@ -52,11 +52,12 @@ class BelgaAFPNewsMLOneTestCase(BelgaTestCase):
                                             'scheme': 'of_interest_to'},
                                            {'name': 'MOA-TFG-1=MOA', 'qcode': 'MOA-TFG-1=MOA',
                                             'scheme': 'of_interest_to'},
-                                           {'name': 'ECONOMY', 'qcode': 'ECONOMY', 'scheme': 'news_products'},
-                                           {'name': 'NEWS', 'qcode': 'NEWS', 'scheme': 'news_services'}])
+                                           {'name': 'POLITICS', 'qcode': 'POLITICS', 'scheme': 'news_products'},
+                                           {'name': 'AFP', 'qcode': 'AFP', 'scheme': 'credits'},
+                                           {'name': 'default', 'qcode': 'default', 'scheme': 'distribution'},
+                                           {'name': 'NEWS', 'qcode': 'NEWS', 'scheme': 'news_services'}
+                                           ])
         self.assertEqual(item["priority"], 4)
-        self.assertEqual(item["credits"], 'AFP')
-        self.assertEqual(item["distribution"], 'default')
         self.assertEqual(item["provider_id"], "afp.com")
         self.assertEqual(item["date_id"], "20190121T104233Z")
         self.assertEqual(item["item_id"], "TX-PAR-RHO61")
@@ -76,7 +77,7 @@ class BelgaAFPNewsMLOneTestCase(BelgaTestCase):
         self.assertEqual(item["line_text"], "(Croquis d'audience+Photo+Video)")
         self.assertEqual(item["administrative"], {'provider': 'AFP'})
         self.assertEqual(item["language"], "fr")
-        self.assertEqual(item["anpa_category"], [{'qcode': 'CLJ'}, {'qcode': 'POL'}])
+        self.assertEqual(item["anpa_category"], [{'qcode': 'POL'}, {'qcode': 'CLJ'}, {'qcode': 'ECO'}])
         self.assertEqual(item["extra"], {'how_present': 'Origin', 'country': 'FRA', 'city': 'Paris'})
         self.assertEqual(item["generator_software"], "libg2")
         self.assertEqual(item["keywords"], ['France', 'procès', 'assises', 'drogues', 'police', 'marches_test'])

--- a/server/tests/io/feed_parsers/belga_afp_newsml_1_2_test.py
+++ b/server/tests/io/feed_parsers/belga_afp_newsml_1_2_test.py
@@ -35,28 +35,34 @@ class BelgaAFPNewsMLOneTestCase(BelgaTestCase):
     def test_content(self):
         item = self.item[0]
         self.assertEqual(item["ingest_provider_sequence"], "0579")
-        self.assertEqual(item["subject"], [{'name': 'News', 'qcode': 'News', 'scheme': 'news_item_types'},
-                                           {'qcode': '02001004', 'name': 'drug trafficking',
-                                            'scheme': 'iptc_subject_codes'},
-                                           {'qcode': '02008000', 'name': 'trials', 'scheme': 'iptc_subject_codes'},
-                                           {'qcode': '02003000', 'name': 'police', 'scheme': 'iptc_subject_codes'},
-                                           {'qcode': '02000000', 'name': 'crime, law and justice',
-                                            'scheme': 'iptc_subject_codes'},
-                                           {'name': 'DAB-TFG-1=DAB', 'qcode': 'DAB-TFG-1=DAB',
-                                            'scheme': 'of_interest_to'},
-                                           {'name': 'AMN-TFG-1=AMW', 'qcode': 'AMN-TFG-1=AMW',
-                                            'scheme': 'of_interest_to'},
-                                           {'name': 'ARC-TFG-1=ELU', 'qcode': 'ARC-TFG-1=ELU',
-                                            'scheme': 'of_interest_to'},
-                                           {'name': 'EUA-TFG-1=EUA', 'qcode': 'EUA-TFG-1=EUA',
-                                            'scheme': 'of_interest_to'},
-                                           {'name': 'MOA-TFG-1=MOA', 'qcode': 'MOA-TFG-1=MOA',
-                                            'scheme': 'of_interest_to'},
-                                           {'name': 'POLITICS', 'qcode': 'POLITICS', 'scheme': 'news_products'},
-                                           {'name': 'AFP', 'qcode': 'AFP', 'scheme': 'credits'},
-                                           {'name': 'default', 'qcode': 'default', 'scheme': 'distribution'},
-                                           {'name': 'NEWS', 'qcode': 'NEWS', 'scheme': 'news_services'}
-                                           ])
+        self.assertEqual(item["subject"].sort(key=lambda i: i['name']),
+                         [{'name': 'News', 'qcode': 'News', 'scheme': 'news_item_types'},
+                          {'qcode': '02001004', 'name': 'drug trafficking',
+                           'scheme': 'iptc_subject_codes'},
+                          {'qcode': '02008000', 'name': 'trials',
+                             'scheme': 'iptc_subject_codes'},
+                          {'qcode': '02003000', 'name': 'police',
+                             'scheme': 'iptc_subject_codes'},
+                          {'qcode': '02000000', 'name': 'crime, law and justice',
+                             'scheme': 'iptc_subject_codes'},
+                          {'name': 'DAB-TFG-1=DAB', 'qcode': 'DAB-TFG-1=DAB',
+                             'scheme': 'of_interest_to'},
+                          {'name': 'AMN-TFG-1=AMW', 'qcode': 'AMN-TFG-1=AMW',
+                             'scheme': 'of_interest_to'},
+                          {'name': 'ARC-TFG-1=ELU', 'qcode': 'ARC-TFG-1=ELU',
+                             'scheme': 'of_interest_to'},
+                          {'name': 'EUA-TFG-1=EUA', 'qcode': 'EUA-TFG-1=EUA',
+                             'scheme': 'of_interest_to'},
+                          {'name': 'MOA-TFG-1=MOA', 'qcode': 'MOA-TFG-1=MOA',
+                             'scheme': 'of_interest_to'},
+                          {'name': 'POLITICS', 'qcode': 'POLITICS',
+                             'scheme': 'news_products'},
+                          {'name': 'AFP', 'qcode': 'AFP', 'scheme': 'credits'},
+                          {'name': 'default', 'qcode': 'default',
+                             'scheme': 'distribution'},
+                          {'name': 'NEWS', 'qcode': 'NEWS',
+                             'scheme': 'news_services'}
+                          ].sort(key=lambda i: i['name']))
         self.assertEqual(item["priority"], 4)
         self.assertEqual(item["provider_id"], "afp.com")
         self.assertEqual(item["date_id"], "20190121T104233Z")

--- a/server/tests/io/feed_parsers/belga_anp_newsml_1_2_test.py
+++ b/server/tests/io/feed_parsers/belga_anp_newsml_1_2_test.py
@@ -41,11 +41,11 @@ class BelgaANPNewsMLOneTestCase(BelgaTestCase):
             {'name': 'no', 'qcode': 'no', 'scheme': 'equivalents_list'},
             {'name': 'ECO', 'qcode': 'ECO', 'scheme': 'genre'},
             {'name': 'ECONOMY', 'qcode': 'ECONOMY', 'scheme': 'news_products'},
-            {'name': 'NEWS', 'qcode': 'NEWS', 'scheme': 'news_services'},
+            {'name': 'ANP', 'qcode': 'ANP', 'scheme': 'credits'},
+            {'name': 'default', 'qcode': 'default', 'scheme': 'distribution'},
+            {'name': 'NEWS', 'qcode': 'NEWS', 'scheme': 'news_services'}
         ])
         self.assertEqual(item["priority"], 3)
-        self.assertEqual(item["credits"], 'ANP')
-        self.assertEqual(item["distribution"], 'default')
         self.assertEqual(item["sentfrom"], {'comment': 'News Provider', 'party': 'Algemeen Nederlands Persbureau'})
         self.assertEqual(item["provider_id"], "ANP")
         self.assertEqual(item["date_id"], "20181210")

--- a/server/tests/io/feed_parsers/belga_anp_newsml_1_2_test.py
+++ b/server/tests/io/feed_parsers/belga_anp_newsml_1_2_test.py
@@ -35,7 +35,7 @@ class BelgaANPNewsMLOneTestCase(BelgaTestCase):
     def test_content(self):
         item = self.item[0]
         self.assertEqual(item["ingest_provider_sequence"], "20181210123731041")
-        self.assertEqual(item["subject"], [
+        self.assertEqual(item["subject"].sort(key=lambda i: i['name']), [
             {'name': 'News', 'qcode': 'News', 'scheme': 'news_item_types'},
             {'name': 'no', 'qcode': 'no', 'scheme': 'essential'},
             {'name': 'no', 'qcode': 'no', 'scheme': 'equivalents_list'},
@@ -44,7 +44,7 @@ class BelgaANPNewsMLOneTestCase(BelgaTestCase):
             {'name': 'ANP', 'qcode': 'ANP', 'scheme': 'credits'},
             {'name': 'default', 'qcode': 'default', 'scheme': 'distribution'},
             {'name': 'NEWS', 'qcode': 'NEWS', 'scheme': 'news_services'}
-        ])
+        ].sort(key=lambda i: i['name']))
         self.assertEqual(item["priority"], 3)
         self.assertEqual(item["sentfrom"], {'comment': 'News Provider', 'party': 'Algemeen Nederlands Persbureau'})
         self.assertEqual(item["provider_id"], "ANP")

--- a/server/tests/io/feed_parsers/belga_anp_newsml_1_2_test.py
+++ b/server/tests/io/feed_parsers/belga_anp_newsml_1_2_test.py
@@ -44,6 +44,8 @@ class BelgaANPNewsMLOneTestCase(BelgaTestCase):
             {'name': 'NEWS', 'qcode': 'NEWS', 'scheme': 'news_services'},
         ])
         self.assertEqual(item["priority"], 3)
+        self.assertEqual(item["credits"], 'ANP')
+        self.assertEqual(item["distribution"], 'default')
         self.assertEqual(item["sentfrom"], {'comment': 'News Provider', 'party': 'Algemeen Nederlands Persbureau'})
         self.assertEqual(item["provider_id"], "ANP")
         self.assertEqual(item["date_id"], "20181210")

--- a/server/tests/io/feed_parsers/belga_anpa_test.py
+++ b/server/tests/io/feed_parsers/belga_anpa_test.py
@@ -28,12 +28,16 @@ class KyodoBelgaFeedParserTestCase(BaseBelgaANPAFeedParserTestCase):
         self.assertEqual(item["firstcreated"].isoformat(), "2018-12-09T12:18:00+00:00")
         self.assertEqual(item["headline"], "Soccer: Urawa Reds claim 7th Emperor's Cup by beating Vegalta Sendai")
         self.assertEqual(item["versioncreated"].isoformat(), "2018-12-09T12:18:00+00:00")
-        self.assertEqual(item["priority"], 6)
-        self.assertEqual(item["anpa_category"], [{'qcode': 'S'}])
+        self.assertEqual(item["priority"], 2)
+        self.assertEqual(item["anpa_category"], [{'qcode': "S"}])
         self.assertEqual(item["format"], "preserved")
         self.assertEqual(item["type"], "text")
-        self.assertListEqual(item["subject"], [{'qcode': 'SPORTS', 'name': 'SPORTS', 'scheme': 'news_products'},
-                                               {'qcode': 'NEWS', 'name': 'NEWS', 'scheme': 'news_services'}])
+        self.assertEqual(item["extra"], {"city": "SAITAMA"})
+        self.assertListEqual(item["subject"], [{'name': 'SPORTS', 'qcode': 'SPORTS', 'scheme': 'news_products'},
+                                               {'name': 'NEWS', 'qcode': 'NEWS', 'scheme': 'news_services'},
+                                               {'name': 'KYODO', 'qcode': 'KYODO', 'scheme': 'credits'},
+                                               {'name': 'default', 'qcode': 'default', 'scheme': 'distribution'}])
+        self.assertEqual(item["priority"], 2)
         expected_body = \
             (
                 '<p>     SAITAMA, Japan, Dec. 9 Kyodo - Urawa Reds claimed their seventh </p><p>E'

--- a/server/tests/io/feed_parsers/belga_anpa_test.py
+++ b/server/tests/io/feed_parsers/belga_anpa_test.py
@@ -22,6 +22,7 @@ class KyodoBelgaFeedParserTestCase(BaseBelgaANPAFeedParserTestCase):
 
     def test_content(self):
         item = self.item
+        self.assertEqual(item["language"], 'en')
         self.assertEqual(item["slugline"], "Soccer-Emperor's-Cup")
         self.assertEqual(item["anpa_take_key"], "'s-Cup")
         self.assertEqual(item["word_count"], 344)

--- a/server/tests/io/feed_parsers/belga_ats_newsml_1_2_test.py
+++ b/server/tests/io/feed_parsers/belga_ats_newsml_1_2_test.py
@@ -33,7 +33,7 @@ class BelgaATSNewsMLOneTestCase(BelgaTestCase):
 
     def test_content(self):
         item = self.item[0]
-        self.assertEqual(item["subject"],
+        self.assertEqual(item["subject"].sort(key=lambda i: i['name']),
                          [{'name': 'News', 'qcode': 'News', 'scheme': 'news_item_types'},
                           {'name': 'ATS', 'qcode': 'ATS', 'scheme': 'credits'},
                           {'name': 'Current', 'qcode': 'Current', 'scheme': 'genre'},
@@ -44,7 +44,8 @@ class BelgaATSNewsMLOneTestCase(BelgaTestCase):
                            'scheme': 'iptc_subject_codes'},
                           {'name': 'GENERAL', 'qcode': 'GENERAL', 'scheme': 'news_products'},
                           {'name': 'default', 'qcode': 'default', 'scheme': 'distribution'},
-                          {'name': 'NEWS', 'qcode': 'NEWS', 'scheme': 'news_services'}])
+                          {'name': 'NEWS', 'qcode': 'NEWS', 'scheme': 'news_services'}
+                          ].sort(key=lambda i: i['name']))
         self.assertEqual(item["priority"], 4)
         self.assertEqual(item["provider_id"], "www.sda-ats.ch")
         self.assertEqual(item["date_id"], "20190603")

--- a/server/tests/io/feed_parsers/belga_ats_newsml_1_2_test.py
+++ b/server/tests/io/feed_parsers/belga_ats_newsml_1_2_test.py
@@ -35,6 +35,7 @@ class BelgaATSNewsMLOneTestCase(BelgaTestCase):
         item = self.item[0]
         self.assertEqual(item["subject"],
                          [{'name': 'News', 'qcode': 'News', 'scheme': 'news_item_types'},
+                          {'name': 'ATS', 'qcode': 'ATS', 'scheme': 'credits'},
                           {'name': 'Current', 'qcode': 'Current', 'scheme': 'genre'},
                           {'qcode': '04001000', 'name': 'agriculture', 'scheme': 'iptc_subject_codes'},
                           {'qcode': '04007000', 'name': 'consumer goods', 'scheme': 'iptc_subject_codes'},
@@ -42,6 +43,7 @@ class BelgaATSNewsMLOneTestCase(BelgaTestCase):
                           {'qcode': '04000000', 'name': 'economy, business and finance',
                            'scheme': 'iptc_subject_codes'},
                           {'name': 'GENERAL', 'qcode': 'GENERAL', 'scheme': 'news_products'},
+                          {'name': 'default', 'qcode': 'default', 'scheme': 'distribution'},
                           {'name': 'NEWS', 'qcode': 'NEWS', 'scheme': 'news_services'}])
         self.assertEqual(item["priority"], 4)
         self.assertEqual(item["provider_id"], "www.sda-ats.ch")

--- a/server/tests/io/feed_parsers/belga_dpa_newsml_2_0_test.py
+++ b/server/tests/io/feed_parsers/belga_dpa_newsml_2_0_test.py
@@ -63,14 +63,15 @@ class BelgaDPANewsMLTwoTestCase(BelgaTestCase):
         self.assertEqual(item["headline"], "Mehr als 200 Migranten in der Ägäis aufgegriffen")
         self.assertEqual(item["slugline"], "")
         self.assertEqual(item["language"], "de")
-        self.assertEqual(item["subject"], [{'qcode': '11017000', 'name': 'Migration', 'scheme': 'iptc_subject_code'},
-                                           {'qcode': '11011000', 'name': 'Flüchtling, Asyl',
-                                            'scheme': 'iptc_subject_code'},
-                                           {'name': 'NEWS', 'qcode': 'NEWS', 'scheme': 'news_services'},
-                                           {'name': 'POLITICS', 'qcode': 'POLITICS', 'scheme': 'news_products'},
-                                           {'name': 'DPA', 'qcode': 'DPA', 'scheme': 'credits'},
-                                           {'name': 'default', 'qcode': 'default', 'scheme': 'distribution'}
-                                           ])
+        self.assertEqual(item["subject"].sort(key=lambda i: i['name']),
+                         [{'qcode': '11017000', 'name': 'Migration', 'scheme': 'iptc_subject_code'},
+                          {'qcode': '11011000', 'name': 'Flüchtling, Asyl',
+                           'scheme': 'iptc_subject_code'},
+                          {'name': 'NEWS', 'qcode': 'NEWS', 'scheme': 'news_services'},
+                          {'name': 'POLITICS', 'qcode': 'POLITICS', 'scheme': 'news_products'},
+                          {'name': 'DPA', 'qcode': 'DPA', 'scheme': 'credits'},
+                          {'name': 'default', 'qcode': 'default', 'scheme': 'distribution'}
+                          ].sort(key=lambda i: i['name']))
         self.assertEqual(item["extra"], {'city': 'Athen', 'country': 'Griechenland'})
         self.assertEqual(item["genre"], [])
         self.assertEqual(item["authors"], [{'uri': None, 'role': 'tsafos'}])

--- a/server/tests/io/feed_parsers/belga_dpa_newsml_2_0_test.py
+++ b/server/tests/io/feed_parsers/belga_dpa_newsml_2_0_test.py
@@ -65,7 +65,13 @@ class BelgaDPANewsMLTwoTestCase(BelgaTestCase):
         self.assertEqual(item["language"], "de")
         self.assertEqual(item["subject"], [{'qcode': '11017000', 'name': 'Migration', 'scheme': 'iptc_subject_code'},
                                            {'qcode': '11011000', 'name': 'Flüchtling, Asyl',
-                                            'scheme': 'iptc_subject_code'}])
+                                            'scheme': 'iptc_subject_code'},
+                                           {'name': 'NEWS', 'qcode': 'NEWS', 'scheme': 'news_services'},
+                                           {'name': 'POLITICS', 'qcode': 'POLITICS', 'scheme': 'news_products'},
+                                           {'name': 'DPA', 'qcode': 'DPA', 'scheme': 'credits'},
+                                           {'name': 'default', 'qcode': 'default', 'scheme': 'distribution'}
+                                           ])
+        self.assertEqual(item["extra"], {'city': 'Athen', 'country': 'Griechenland'})
         self.assertEqual(item["genre"], [])
         self.assertEqual(item["authors"], [{'uri': None, 'role': 'tsafos'}])
         self.assertEqual(item["dateline"], {'text': 'Athen (dpa) - '})

--- a/server/tests/io/feed_parsers/belga_efe_newsml_1_2_test.py
+++ b/server/tests/io/feed_parsers/belga_efe_newsml_1_2_test.py
@@ -34,14 +34,14 @@ class BelgaEFENewsMLOneTestCase(BelgaTestCase):
 
     def test_content(self):
         item = self.item[0]
-        self.assertEqual(item["subject"], [
-            {'name': 'News', 'qcode': 'News', 'scheme': 'news_item_types'},
-            {'qcode': '01026000', 'name': 'mass media', 'scheme': 'iptc_subject_codes'},
-            {'qcode': 'POLITICS', 'name': 'POLITICS', 'scheme': 'news_products'},
-            {'name': 'EFE', 'qcode': 'EFE', 'scheme': 'credits'},
-            {'name': 'default', 'qcode': 'default', 'scheme': 'distribution'},
-            {'qcode': 'NEWS', 'name': 'NEWS', 'scheme': 'news_services'}
-        ])
+        self.assertEqual(item["subject"].sort(key=lambda i: i['name']),
+                         [{'name': 'News', 'qcode': 'News', 'scheme': 'news_item_types'},
+                          {'qcode': '01026000', 'name': 'mass media', 'scheme': 'iptc_subject_codes'},
+                          {'qcode': 'POLITICS', 'name': 'POLITICS', 'scheme': 'news_products'},
+                          {'name': 'EFE', 'qcode': 'EFE', 'scheme': 'credits'},
+                          {'name': 'default', 'qcode': 'default', 'scheme': 'distribution'},
+                          {'qcode': 'NEWS', 'name': 'NEWS', 'scheme': 'news_services'}
+                          ].sort(key=lambda i: i['name']))
         self.assertEqual(item['anpa_category'], [{'qcode': 'POL'}])
         self.assertEqual(item["sentfrom"], {'party': 'EFE', 'organization': 'Agencia EFE'})
         self.assertEqual(item["duid"], "text_25413502")

--- a/server/tests/io/feed_parsers/belga_efe_newsml_1_2_test.py
+++ b/server/tests/io/feed_parsers/belga_efe_newsml_1_2_test.py
@@ -38,6 +38,8 @@ class BelgaEFENewsMLOneTestCase(BelgaTestCase):
             {'name': 'News', 'qcode': 'News', 'scheme': 'news_item_types'},
             {'qcode': '01026000', 'name': 'mass media', 'scheme': 'iptc_subject_codes'},
             {'qcode': 'POLITICS', 'name': 'POLITICS', 'scheme': 'news_products'},
+            {'name': 'EFE', 'qcode': 'EFE', 'scheme': 'credits'},
+            {'name': 'default', 'qcode': 'default', 'scheme': 'distribution'},
             {'qcode': 'NEWS', 'name': 'NEWS', 'scheme': 'news_services'}
         ])
         self.assertEqual(item['anpa_category'], [{'qcode': 'POL'}])

--- a/server/tests/io/feed_parsers/belga_iptc7901_test.py
+++ b/server/tests/io/feed_parsers/belga_iptc7901_test.py
@@ -1,5 +1,6 @@
-from superdesk.tests import TestCase
 import os
+
+from superdesk.tests import TestCase
 from belga.io.feed_parsers.belga_iptc7901 import BelgaIPTC7901FeedParser
 
 
@@ -87,13 +88,12 @@ class DPABelgaFeedParserTestCase(BaseBelgaIPTC7901FeedParserTestCase):
         self.assertEqual(item["body_html"], expected_body)
 
 
-class ATSBelgaFeedParserTestCase(DPABelgaFeedParserTestCase):
+class ATSBelgaFeedParserTestCase(BaseBelgaIPTC7901FeedParserTestCase):
     filename = 'ats.txt'
 
     def test_content(self):
         item = self.item
-        self.assertEqual(item["ingest_provider_sequence"], "037")
-        # self.assertEqual(item["slugline"], "Notes de frais GE")
+        self.assertEqual(item["ingest_provider_sequence"], "025")
         self.assertEqual(item["anpa_category"], [{'qcode': 'EC'}])
         self.assertListEqual(item["subject"], [{'qcode': 'ECONOMY', 'name': 'ECONOMY', 'scheme': 'news_products'},
                                                {'qcode': 'NEWS', 'name': 'NEWS', 'scheme': 'news_services'},
@@ -101,33 +101,27 @@ class ATSBelgaFeedParserTestCase(DPABelgaFeedParserTestCase):
                                                {'name': 'default', 'qcode': 'default', 'scheme': 'distribution'}
                                                ])
         self.assertEqual(item["type"], "text")
+        self.assertEqual(item["language"], "fr")
+        self.assertEqual(item["extra"], {'city': 'Paris'})
         self.assertEqual(item["original_source"], "bsf")
-        expected_headline = \
-            (
-                "Notes de frais GE: \r\nL'affaire des notes de frais a marquÃ© l'exÃ©cutif de la Vi"
-                'lle'
-            )
-        self.assertEqual(item["headline"], expected_headline)
-        self.assertEqual(item["priority"], 4)
-        self.assertEqual(item["word_count"], 174)
+        self.assertEqual(item["headline"], 'Gilets jaunes: une «catastrophe pour notre économie» (Le Maire) =')
+        self.assertEqual(item["priority"], 3)
+        self.assertEqual(item["word_count"], 121)
         expected_body = \
             (
-                '<p> GenÃ¨ve (ats) Le scandale causÃ© par les notes de frais  considÃ©rables de c'
-                'ertains conseillers administratifs de la Ville de  GenÃ¨ve a provoquÃ© un sÃ©ism'
-                "e au sein de l'exÃ©cutif municipal. Â«Le  rapport de confiance a Ã©tÃ© Ã©branlÃ©"
-                'Â», a admis le maire de la Ville  de GenÃ¨ve Sami Kanaan, dans une interview lun'
-                'di Ã\xa0 la Tribune de  GenÃ¨ve.   Â«Il y aura un avant et un aprÃ¨s rapport de la '
-                "Cour des comptesÂ»,  souligne l'Ã©lu socialiste. Ce dernier dit avoir Â«Ã©tÃ© ch"
-                'oquÃ© de  dÃ©couvrir certaines pratiques trÃ¨s discutablesÂ». Le magistrat  appe'
-                'lle maintenant Ã\xa0 tourner la page, afin de Â«repartir sur des  bases sainesÂ».  '
-                " Une quinzaine de textes liÃ©s Ã\xa0 l'affaire ont Ã©tÃ© dÃ©posÃ©s au  Conseil muni"
-                'cipal. Le dÃ©libÃ©ratif devra les traiter le plus  rapidement, estime M. Kanaan,'
-                " dans le but Â«de ne pas handicaper  d'autres dossiers importantsÂ». Selon le ma"
-                'ire de GenÃ¨ve, ce travail  devrait Ãªtre fait Â«dans les quatre Ã\xa0 six prochain'
-                'es semainesÂ».   Des mesures ont dÃ©jÃ\xa0 Ã©tÃ© prises. Un dispositif des frais a '
-                'Ã©tÃ©  crÃ©Ã©. Une charte des valeurs sera instaurÃ©e, qui complÃ©tera une  vers'
-                "ion actualisÃ©e de la rÃ©glementation sur les frais. Â«L'enjeu, ce  ne sont pas "
-                'seulement les rÃ¨gles, mais aussi les attitudes et les  comportements face Ã\xa0 el'
-                'lesÂ», note le maire.   (SDA\\/mf ba)   </p>'
+                "<p>«gilets jaunes» sont une «catastrophe» pour l'économie, a estimé  </p>"
+                "<p>dimanche le ministre de l'Economie. Bruno Le Maire a été jusqu'à  </p>"
+                "<p>parler d'une «crise de la nation».  </p><p>  </p>"
+                "<p>   «C'est une catastrophe pour le commerce, c'est une catastrophe  </p>"
+                "<p>pour notre économie», a déclaré à la presse le ministre, lors d'une  </p>"
+                "<p>visite aux commerçants à Paris au lendemain de nouvelles violences  </p>"
+                "<p>lors de la quatrième journée de mobilisation. Il a énuméré «une  </p>"
+                "<p>crise sociale», «une crise démocratique» et «une crise de la  </p><p>nation».  </p><p>  </p>"
+                "<p>   De son côté, Ségolène Royal, ancienne finaliste de la  </p>"
+                "<p>présidentielle de 2007, a fustigé dimanche des «décisions mal  </p>"
+                "<p>préparées» par le gouvernement ayant conduit, selon elle, à la  </p>"
+                "<p>crise des «gilets jaunes» en raison de leur impact sur le pouvoir  </p>"
+                "<p>d'achat.  </p><p>  </p><p>(SDA\\/sj)  </p><p>  </p>"
+                "<p>\x03091223 dec 18 </p><p> </p><p> </p><p>\x04 </p>"
             )
         self.assertEqual(item["body_html"], expected_body)

--- a/server/tests/io/feed_parsers/belga_iptc7901_test.py
+++ b/server/tests/io/feed_parsers/belga_iptc7901_test.py
@@ -27,7 +27,10 @@ class DPABelgaFeedParserTestCase(BaseBelgaIPTC7901FeedParserTestCase):
         self.assertEqual(item["slugline"], "/politics/Britain/EU/Brexit/justice")
         self.assertEqual(item["anpa_category"], [{'qcode': 'I'}])
         self.assertListEqual(item["subject"], [{'qcode': 'POLITICS', 'name': 'POLITICS', 'scheme': 'news_products'},
-                                               {'qcode': 'NEWS', 'name': 'NEWS', 'scheme': 'news_services'}])
+                                               {'qcode': 'NEWS', 'name': 'NEWS', 'scheme': 'news_services'},
+                                               {'name': 'DPA', 'qcode': 'DPA', 'scheme': 'credits'},
+                                               {'name': 'default', 'qcode': 'default', 'scheme': 'distribution'}
+                                               ])
         self.assertEqual(item["type"], "text")
         self.assertEqual(item["byline"], "Helen Maguire, dpa")
         expected_body = \
@@ -93,7 +96,10 @@ class ATSBelgaFeedParserTestCase(DPABelgaFeedParserTestCase):
         # self.assertEqual(item["slugline"], "Notes de frais GE")
         self.assertEqual(item["anpa_category"], [{'qcode': 'EC'}])
         self.assertListEqual(item["subject"], [{'qcode': 'ECONOMY', 'name': 'ECONOMY', 'scheme': 'news_products'},
-                                               {'qcode': 'NEWS', 'name': 'NEWS', 'scheme': 'news_services'}])
+                                               {'qcode': 'NEWS', 'name': 'NEWS', 'scheme': 'news_services'},
+                                               {'name': 'ATS', 'qcode': 'ATS', 'scheme': 'credits'},
+                                               {'name': 'default', 'qcode': 'default', 'scheme': 'distribution'}
+                                               ])
         self.assertEqual(item["type"], "text")
         self.assertEqual(item["original_source"], "bsf")
         expected_headline = \

--- a/server/tests/io/feed_parsers/belga_tass_newsml_1_2_test.py
+++ b/server/tests/io/feed_parsers/belga_tass_newsml_1_2_test.py
@@ -41,7 +41,6 @@ class BelgaTASSNewsMLOneTestCase(TestCase):
             {'name': 'TASS', 'qcode': 'TASS', 'scheme': 'credits'},
             {'name': 'default', 'qcode': 'default', 'scheme': 'distribution'},
             {'name': 'NEWS', 'qcode': 'NEWS', 'scheme': 'news_services'}
-            
         ])
         self.assertEqual(item["provider_id"], "\nwww.itar-tass.com\n")
         self.assertEqual(str(item["firstcreated"]), "2019-01-21 07:27:08+00:00")

--- a/server/tests/io/feed_parsers/belga_tass_newsml_1_2_test.py
+++ b/server/tests/io/feed_parsers/belga_tass_newsml_1_2_test.py
@@ -38,7 +38,10 @@ class BelgaTASSNewsMLOneTestCase(TestCase):
             {'name': 'no', 'qcode': 'no', 'scheme': 'essential'},
             {'name': 'no', 'qcode': 'no', 'scheme': 'equivalents_list'},
             {'name': 'ECONOMY', 'qcode': 'ECONOMY', 'scheme': 'news_products'},
-            {'name': 'NEWS', 'qcode': 'NEWS', 'scheme': 'news_services'},
+            {'name': 'TASS', 'qcode': 'TASS', 'scheme': 'credits'},
+            {'name': 'default', 'qcode': 'default', 'scheme': 'distribution'},
+            {'name': 'NEWS', 'qcode': 'NEWS', 'scheme': 'news_services'}
+            
         ])
         self.assertEqual(item["provider_id"], "\nwww.itar-tass.com\n")
         self.assertEqual(str(item["firstcreated"]), "2019-01-21 07:27:08+00:00")

--- a/server/tests/io/feed_parsers/belga_tass_newsml_1_2_test.py
+++ b/server/tests/io/feed_parsers/belga_tass_newsml_1_2_test.py
@@ -32,7 +32,7 @@ class BelgaTASSNewsMLOneTestCase(TestCase):
 
     def test_content(self):
         item = self.item[0]
-        self.assertEqual(item["subject"], [
+        self.assertEqual(item["subject"].sort(key=lambda i: i['name']), [
             {'name': 'normal', 'qcode': 'normal', 'scheme': 'link_type'},
             {'name': 'News', 'qcode': 'News', 'scheme': 'news_item_types'},
             {'name': 'no', 'qcode': 'no', 'scheme': 'essential'},
@@ -41,7 +41,7 @@ class BelgaTASSNewsMLOneTestCase(TestCase):
             {'name': 'TASS', 'qcode': 'TASS', 'scheme': 'credits'},
             {'name': 'default', 'qcode': 'default', 'scheme': 'distribution'},
             {'name': 'NEWS', 'qcode': 'NEWS', 'scheme': 'news_services'}
-        ])
+        ].sort(key=lambda i: i['name']))
         self.assertEqual(item["provider_id"], "\nwww.itar-tass.com\n")
         self.assertEqual(str(item["firstcreated"]), "2019-01-21 07:27:08+00:00")
         self.assertEqual(str(item["versioncreated"]), "2019-01-21 04:27:08+00:00")

--- a/server/tests/io/fixtures/afp_belga.xml
+++ b/server/tests/io/fixtures/afp_belga.xml
@@ -94,7 +94,7 @@
 <Property FormalName="Keyword" Value="assises"/>
 <Property FormalName="Keyword" Value="drogues"/>
 <Property FormalName="Keyword" Value="police"/>
-<Property FormalName="Keyword" Value="marches"/>
+<Property FormalName="Keyword" Value="marches_test"/>
 </DescriptiveMetadata>
 <ContentItem>
 <MediaType FormalName="Text"/>

--- a/server/tests/io/fixtures/afp_belga.xml
+++ b/server/tests/io/fixtures/afp_belga.xml
@@ -55,13 +55,13 @@
 <SubjectMatter FormalName="02008000" cat="CLJ"/>
 </SubjectCode>
 <SubjectCode>
-<SubjectDetail FormalName="02001004" cat="CLJ"/>
+<SubjectDetail FormalName="02001004" cat="POL"/>
 </SubjectCode>
 <SubjectCode>
 <SubjectMatter FormalName="02003000" cat="CLJ"/>
 </SubjectCode>
 <SubjectCode>
-<SubjectMatter FormalName="02001000" cat="POL"/>
+<SubjectMatter FormalName="02001000" cat="ECO"/>
 </SubjectCode>
 <SubjectCode>
 <Subject FormalName="02000000" cat="CLJ"/>

--- a/server/tests/io/fixtures/afp_belga.xml
+++ b/server/tests/io/fixtures/afp_belga.xml
@@ -82,6 +82,7 @@
 <OfInterestTo FormalName="AMN-TFG-1=AMW"/>
 <OfInterestTo FormalName="ARC-TFG-1=ELU"/>
 <OfInterestTo FormalName="EUA-TFG-1=EUA"/>
+<OfInterestTo FormalName="EUA-TFG-1=EUA"/>
 <OfInterestTo FormalName="MOA-TFG-1=MOA"/>
 <DateLineDate>20190121T104233+0000</DateLineDate>
 <Location HowPresent="Origin">

--- a/server/tests/io/fixtures/ats.txt
+++ b/server/tests/io/fixtures/ats.txt
@@ -1,36 +1,33 @@
-
-bsf037 4 ec 174 gef 1388
+
+bsf025 3 ec 121   etf 967
 
-Notes de frais GE
+France
 
-Notes de frais GE: 
-L'affaire des notes de frais a marquÃ© l'exÃ©cutif de la Ville = 
+Situation 
+France:  
+Gilets jaunes: une «catastrophe pour notre économie» (Le Maire) = 
+ 
+   Paris (ats afp) Les violences liées aux manifestations des 
+«gilets jaunes» sont une «catastrophe» pour l'économie, a estimé 
+dimanche le ministre de l'Economie. Bruno Le Maire a été jusqu'à 
+parler d'une «crise de la nation». 
+ 
+   «C'est une catastrophe pour le commerce, c'est une catastrophe 
+pour notre économie», a déclaré à la presse le ministre, lors d'une 
+visite aux commerçants à Paris au lendemain de nouvelles violences 
+lors de la quatrième journée de mobilisation. Il a énuméré «une 
+crise sociale», «une crise démocratique» et «une crise de la 
+nation». 
+ 
+   De son côté, Ségolène Royal, ancienne finaliste de la 
+présidentielle de 2007, a fustigé dimanche des «décisions mal 
+préparées» par le gouvernement ayant conduit, selon elle, à la 
+crise des «gilets jaunes» en raison de leur impact sur le pouvoir 
+d'achat. 
+ 
+(SDA\/sj) 
+ 
+091223 dec 18
 
-GenÃ¨ve (ats) Le scandale causÃ© par les notes de frais 
-considÃ©rables de certains conseillers administratifs de la Ville de 
-GenÃ¨ve a provoquÃ© un sÃ©isme au sein de l'exÃ©cutif municipal. Â«Le 
-rapport de confiance a Ã©tÃ© Ã©branlÃ©Â», a admis le maire de la Ville 
-de GenÃ¨ve Sami Kanaan, dans une interview lundi Ã  la Tribune de 
-GenÃ¨ve. 
 
-Â«Il y aura un avant et un aprÃ¨s rapport de la Cour des comptesÂ», 
-souligne l'Ã©lu socialiste. Ce dernier dit avoir Â«Ã©tÃ© choquÃ© de 
-dÃ©couvrir certaines pratiques trÃ¨s discutablesÂ». Le magistrat 
-appelle maintenant Ã  tourner la page, afin de Â«repartir sur des 
-bases sainesÂ». 
-
-Une quinzaine de textes liÃ©s Ã  l'affaire ont Ã©tÃ© dÃ©posÃ©s au 
-Conseil municipal. Le dÃ©libÃ©ratif devra les traiter le plus 
-rapidement, estime M. Kanaan, dans le but Â«de ne pas handicaper 
-d'autres dossiers importantsÂ». Selon le maire de GenÃ¨ve, ce travail 
-devrait Ãªtre fait Â«dans les quatre Ã  six prochaines semainesÂ». 
-
-Des mesures ont dÃ©jÃ  Ã©tÃ© prises. Un dispositif des frais a Ã©tÃ© 
-crÃ©Ã©. Une charte des valeurs sera instaurÃ©e, qui complÃ©tera une 
-version actualisÃ©e de la rÃ©glementation sur les frais. Â«L'enjeu, ce 
-ne sont pas seulement les rÃ¨gles, mais aussi les attitudes et les 
-comportements face Ã  ellesÂ», note le maire. 
-
-(SDA\/mf ba) 
-
-211005 jan 19
+

--- a/server/tests/io/fixtures/kyodo.txt
+++ b/server/tests/io/fixtures/kyodo.txt
@@ -1,5 +1,5 @@
 a0105KYODOkoko-
-d s BC-Soccer-Emperor's-Cup   09-12 0344
+u s BC-Soccer-Emperor's-Cup   09-12 0344
 BC-Soccer-Emperor's-Cup
 Soccer: Urawa Reds claim 7th Emperor's Cup by beating Vegalta Sendai+
      SAITAMA, Japan, Dec. 9 Kyodo - Urawa Reds claimed their seventh 


### PR DESCRIPTION
SDBELGA-221: The metadata of the DPA ingest is not mapped correctly. 
'News Services' has to be 'NEWS'
'News Products' has to be 'GENERAL', 'ECONOMY', 'SPORTS' or 'CULTURE' as stated in https://dev.sourcefabric.org/browse/SDBELGA-151
'Credits' has to be 'DPA'
'Distribution' has to be 'default'
'City' has to be prefilled based on the original
'Country' has to be prefilled based on the original
'Editorial info' has to be empty 

SDBELGA-222.
'Credits' has to be 'AFP'
'Distribution' has to be 'default'
'Label' has to be empty

SDBELGA-223.
'Credits' has to be 'ANP'
'Distribution' has to be 'default'

update other  TASS, EFE
'Credits' has to be 'TASS','EFE'
'Distribution' has to be 'default'

Update unit-test