### PR TITLE
[SDBELGA-251] Fix ANP ingest mapping for slugline and storytag

### DIFF
--- a/server/belga/io/feed_parsers/belga_anp_newsml_1_2.py
+++ b/server/belga/io/feed_parsers/belga_anp_newsml_1_2.py
@@ -44,6 +44,7 @@ class BelgaANPNewsMLOneFeedParser(BaseBelgaNewsMLOneFeedParser):
         # Credits is ANP
         credit = {"name": 'ANP', "qcode": 'ANP', "scheme": "credits"}
         item.setdefault('subject', []).append(credit)
+        item['slugline'] = ''
         return item
 
 

--- a/server/tests/io/feed_parsers/belga_anp_newsml_1_2_test.py
+++ b/server/tests/io/feed_parsers/belga_anp_newsml_1_2_test.py
@@ -65,7 +65,7 @@ class BelgaANPNewsMLOneTestCase(BelgaTestCase):
         self.assertEqual(item["copyright_line"],
                          "© 2018 ANP. Alle auteursrechten en databankrechten voorbehouden. All copyrights and "
                          "database rights reserved.")
-        self.assertEqual(item["slugline"], "Huub Giesbers (iwi)")
+        self.assertEqual(item["slugline"], "")
         self.assertEqual(item["keyword_line"], "ECO/ECO10;ECO-POST-CAO")
         self.assertEqual(item["administrative"], {'provider': 'ANP'})
         self.assertEqual(item["language"], "nl-nl")


### PR DESCRIPTION
This PR set `slugline` to empty for all ANP ingest items.
For `storytags`, it seems the errors came from [setting storytags `id` to `keywords`](https://user-images.githubusercontent.com/45254285/70695087-87d90980-1cf3-11ea-8fbc-7202859aabf5.png) in vocabularies
