### PR TITLE
[SDBELGA-242] Add slugline for belga 360 search item

### DIFF
--- a/server/belga/search_providers.py
+++ b/server/belga/search_providers.py
@@ -281,6 +281,7 @@ class Belga360ArchiveSearchProvider(superdesk.SearchProvider):
             '_id': guid,
             'guid': guid,
             'headline': get_text(data['headLine']),
+            'slugline': get_text(data['topic']),
             'name': get_text(data['name']),
             'description_text': get_text(data.get('description')),
             'versioncreated': created,

--- a/server/tests/belga_360_archive_test.py
+++ b/server/tests/belga_360_archive_test.py
@@ -73,6 +73,7 @@ class Belga360ArchiveTestCase(unittest.TestCase):
         self.assertEqual(item['extra']['bcoverage'], guid)
         self.assertEqual(item['headline'], 'Lorem ipsum dolor sit amet, consectetur adipiscing elit.')
         self.assertEqual(item['name'], '')
+        self.assertEqual(item['slugline'], 'Belga 360 slugline')
         self.assertEqual(item['description_text'], '')
         self.assertEqual(item['creditline'], 'BELGA')
         self.assertEqual(item['source'], 'BELGA')

--- a/server/tests/fixtures/belga-360archive-search.json
+++ b/server/tests/fixtures/belga-360archive-search.json
@@ -5,7 +5,7 @@
             "assetType": "Short",
             "name": "",
             "credit": "BELGA",
-            "topic": null,
+            "topic": "Belga 360 slugline",
             "headLine": "Lorem ipsum dolor sit amet, consectetur adipiscing elit.",
             "language": "fr",
             "source": "BELGA",


### PR DESCRIPTION
Changes:
- Map field `topic` from belga 360 to `slugline` in superdesk