### PR TITLE
[SDBELGA-266] Add multilingual country for belga ingest item

### DIFF
--- a/server/belga/io/feed_parsers/base_belga_newsml_1_2.py
+++ b/server/belga/io/feed_parsers/base_belga_newsml_1_2.py
@@ -558,6 +558,8 @@ class BaseBelgaNewsMLOneFeedParser(NewsMLOneFeedParser):
                 item['extra']['how_present'] = how_present_el
 
             elements = location_el.findall('Property')
+            # avoid repeatedly calling db while finding country
+            self.country = self._get_cv('country').get('items', [])
             for element in elements:
                 if element.attrib.get('FormalName', '') == 'Country':
                     country = element.attrib.get('Value')
@@ -725,10 +727,10 @@ class BaseBelgaNewsMLOneFeedParser(NewsMLOneFeedParser):
     def _get_cv(self, _id):
         return superdesk.get_resource_service('vocabularies').find_one(req=None, _id=_id)
 
-    def _get_country(self, country):
+    def _get_country(self, country_code):
         country_keyword = [
-            c for c in self._get_cv('country').get('items', [])
-            if c.get('qcode') == 'country_' + country.lower() and c.get('is_active')
+            c for c in self.country
+            if c.get('qcode') == 'country_' + country_code.lower() and c.get('is_active')
         ]
         # add scheme and remove is_active
         for c in country_keyword:

--- a/server/belga/io/feed_parsers/base_belga_newsml_1_2.py
+++ b/server/belga/io/feed_parsers/base_belga_newsml_1_2.py
@@ -17,6 +17,8 @@ from superdesk.etree import etree
 from superdesk.io.feed_parsers.newsml_1_2 import NewsMLOneFeedParser
 from superdesk.io.iptc import subject_codes
 
+from .belga_newsml_mixin import BelgaNewsMLMixin
+
 
 class SkipItemException(Exception):
     """Raised when we current item must be skipped"""
@@ -24,12 +26,8 @@ class SkipItemException(Exception):
     pass
 
 
-class BaseBelgaNewsMLOneFeedParser(NewsMLOneFeedParser):
+class BaseBelgaNewsMLOneFeedParser(BelgaNewsMLMixin, NewsMLOneFeedParser):
     """Base Feed Parser for NewsML format, specific AFP, ANP, .. Belga xml."""
-
-    def __init__(self):
-        super().__init__()
-        self._countries = []
 
     def parse(self, xml, provider=None):
         """
@@ -728,18 +726,3 @@ class BaseBelgaNewsMLOneFeedParser(NewsMLOneFeedParser):
 
     def _get_cv(self, _id):
         return superdesk.get_resource_service('vocabularies').find_one(req=None, _id=_id)
-
-    def _get_country(self, country_code):
-        if not self._countries:
-            self._countries = self._get_cv('country').get('items', [])
-
-        country_keyword = [
-            c for c in self._countries
-            if c.get('qcode') == 'country_' + country_code.lower() and c.get('is_active')
-        ]
-        # add scheme and remove is_active
-        for c in country_keyword:
-            c['scheme'] = 'country'
-            if 'is_active' in c:
-                c.pop('is_active')
-        return country_keyword

--- a/server/belga/io/feed_parsers/base_belga_newsml_1_2.py
+++ b/server/belga/io/feed_parsers/base_belga_newsml_1_2.py
@@ -8,6 +8,7 @@
 # AUTHORS and LICENSE files distributed with this source code, or
 # at https://www.appendsourcefabric.org/superdesk/license
 
+import itertools
 import html
 import datetime
 import superdesk
@@ -85,6 +86,10 @@ class BaseBelgaNewsMLOneFeedParser(NewsMLOneFeedParser):
                     # Slugline and keywords is epmty
                     item['slugline'] = None
                     item['keywords'] = []
+                    # remove dupplicated subject
+                    item['subject'] = [
+                        dict(i) for i, _ in itertools.groupby(sorted(item['subject'], key=lambda k: k['name']))
+                    ]
                     item = self.populate_fields(item)
                 except SkipItemException:
                     continue

--- a/server/belga/io/feed_parsers/belga_ats_newsml_1_2.py
+++ b/server/belga/io/feed_parsers/belga_ats_newsml_1_2.py
@@ -39,7 +39,7 @@ class BelgaATSNewsMLOneFeedParser(BaseBelgaNewsMLOneFeedParser):
         super().parser_newsmanagement(item, manage_el)
         item['firstcreated'] = item['firstcreated'].astimezone(pytz.utc)
         item['versioncreated'] = item['versioncreated'].astimezone(pytz.utc)
-        # Credits is AFP
+        # Credits is ATS
         credit = {"name": 'ATS', "qcode": 'ATS', "scheme": "credits"}
         item.setdefault('subject', []).append(credit)
 

--- a/server/belga/io/feed_parsers/belga_newsml_mixin.py
+++ b/server/belga/io/feed_parsers/belga_newsml_mixin.py
@@ -1,0 +1,27 @@
+# -*- coding: utf-8; -*-
+#
+# This file is part of Superdesk.
+#
+# Copyright 2013 - 2018 Sourcefabric z.u. and contributors.
+#
+# For the full copyright and license information, please see the
+# AUTHORS and LICENSE files distributed with this source code, or
+# at https://www.sourcefabric.org/superdesk/license
+
+from superdesk import get_resource_service
+
+
+class BelgaNewsMLMixin:
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self._countries = []
+
+    def _get_country(self, country_code):
+        if not self._countries:
+            self._countries = get_resource_service('vocabularies').find_one(req=None, _id='country').get('items', [])
+
+        return [
+            {'name': c['name'], 'qcode': c['qcode'], 'translations': c['translations'], 'scheme': 'country'}
+            for c in self._countries
+            if c.get('qcode') == 'country_' + country_code.lower() and c.get('is_active')
+        ]

--- a/server/belga/io/feed_parsers/belga_tass_newsml_1_2.py
+++ b/server/belga/io/feed_parsers/belga_tass_newsml_1_2.py
@@ -63,7 +63,8 @@ class BelgaTASSNewsMLOneFeedParser(BaseBelgaNewsMLOneFeedParser):
         Example:
         <NewsComponent Duid="03AE4325838900396A95" Essential="no" EquivalentsList="no">
             NewsComponent Duid="03AE4325838900396A95">
-                <NewsComponent xml:lang="en"><Role FormalName="Main" />
+                <NewsComponent xml:lang="en">
+                    <Role FormalName="Main" />
                     ....
                 </NewsComponent>
             </NewsComponent>
@@ -72,9 +73,7 @@ class BelgaTASSNewsMLOneFeedParser(BaseBelgaNewsMLOneFeedParser):
         :param newscomponent_el:
         :return:
         """
-        third_newscomponent_el = newscomponent_el.find('NewsComponent/NewsComponent')
-        if third_newscomponent_el is not None:
-            super().parser_newscomponent(item, third_newscomponent_el)
+        super().parser_newscomponent(item, newscomponent_el.find('NewsComponent/NewsComponent'))
         if newscomponent_el.attrib.get('Duid') is not None:
             item['guid'] = newscomponent_el.attrib.get('Duid', '')
         # Essential is CV

--- a/server/tests/io/feed_parsers/belga_afp_newsml_1_2_test.py
+++ b/server/tests/io/feed_parsers/belga_afp_newsml_1_2_test.py
@@ -41,6 +41,7 @@ class BelgaAFPNewsMLOneTestCase(BelgaTestCase):
             {'name': 'trials', 'qcode': '02008000', 'scheme': 'iptc_subject_codes'},
             {'name': 'AMN-TFG-1=AMW', 'qcode': 'AMN-TFG-1=AMW', 'scheme': 'of_interest_to'},
             {'name': 'EUA-TFG-1=EUA', 'qcode': 'EUA-TFG-1=EUA', 'scheme': 'of_interest_to'},
+            {'name': 'EUA-TFG-1=EUA', 'qcode': 'EUA-TFG-1=EUA', 'scheme': 'of_interest_to'},
             {'name': 'AFP', 'qcode': 'AFP', 'scheme': 'credits'},
             {'name': 'crime, law and justice', 'qcode': '02000000', 'scheme': 'iptc_subject_codes'},
             {'name': 'News', 'qcode': 'News', 'scheme': 'news_item_types'},
@@ -48,7 +49,9 @@ class BelgaAFPNewsMLOneTestCase(BelgaTestCase):
             {'name': 'MOA-TFG-1=MOA', 'qcode': 'MOA-TFG-1=MOA', 'scheme': 'of_interest_to'},
             {'name': 'police', 'qcode': '02003000', 'scheme': 'iptc_subject_codes'},
             {'name': 'NEWS/POLITICS', 'parent': 'NEWS', 'qcode': 'NEWS/POLITICS', 'scheme': 'services-products'},
-            {'name': 'default', 'qcode': 'default', 'scheme': 'distribution'}
+            {'name': 'default', 'qcode': 'default', 'scheme': 'distribution'},
+            {'name': 'France', 'qcode': 'country_fra', 'scheme': 'country',
+             'translations': {'name': {'nl': 'Frankrijk', 'fr': 'France'}}},
         ]
         expected_subjects.sort(key=lambda i: i['name'])
         self.assertEqual(item["subject"], expected_subjects)

--- a/server/tests/io/feed_parsers/belga_afp_newsml_1_2_test.py
+++ b/server/tests/io/feed_parsers/belga_afp_newsml_1_2_test.py
@@ -48,6 +48,8 @@ class BelgaAFPNewsMLOneTestCase(BelgaTestCase):
             {'name': 'MOA-TFG-1=MOA', 'qcode': 'MOA-TFG-1=MOA', 'scheme': 'of_interest_to'},
             {'name': 'police', 'qcode': '02003000', 'scheme': 'iptc_subject_codes'},
             {'name': 'NEWS/SPORTS', 'parent': 'NEWS', 'qcode': 'NEWS/SPORTS', 'scheme': 'services-products'},
+            {'name': 'France', 'qcode': 'country_fra', 'scheme': 'country',
+             'translations': {'name': {'fr': 'France', 'nl': 'Frankrijk'}}},
             {'name': 'default', 'qcode': 'default', 'scheme': 'distribution'}
         ]
         expected_subjects.sort(key=lambda i: i['name'])

--- a/server/tests/io/feed_parsers/belga_afp_newsml_1_2_test.py
+++ b/server/tests/io/feed_parsers/belga_afp_newsml_1_2_test.py
@@ -41,7 +41,6 @@ class BelgaAFPNewsMLOneTestCase(BelgaTestCase):
             {'name': 'trials', 'qcode': '02008000', 'scheme': 'iptc_subject_codes'},
             {'name': 'AMN-TFG-1=AMW', 'qcode': 'AMN-TFG-1=AMW', 'scheme': 'of_interest_to'},
             {'name': 'EUA-TFG-1=EUA', 'qcode': 'EUA-TFG-1=EUA', 'scheme': 'of_interest_to'},
-            {'name': 'EUA-TFG-1=EUA', 'qcode': 'EUA-TFG-1=EUA', 'scheme': 'of_interest_to'},
             {'name': 'AFP', 'qcode': 'AFP', 'scheme': 'credits'},
             {'name': 'crime, law and justice', 'qcode': '02000000', 'scheme': 'iptc_subject_codes'},
             {'name': 'News', 'qcode': 'News', 'scheme': 'news_item_types'},

--- a/server/tests/io/feed_parsers/belga_dpa_newsml_2_0_test.py
+++ b/server/tests/io/feed_parsers/belga_dpa_newsml_2_0_test.py
@@ -70,7 +70,11 @@ class BelgaDPANewsMLTwoTestCase(BelgaTestCase):
             {'qcode': '11011000', 'name': 'Flüchtling, Asyl', 'scheme': 'iptc_subject_code'},
             {'name': 'NEWS/POLITICS', 'qcode': 'NEWS/POLITICS', 'parent': 'NEWS', 'scheme': 'services-products'},
             {'name': 'DPA', 'qcode': 'DPA', 'scheme': 'credits'},
-            {'name': 'default', 'qcode': 'default', 'scheme': 'distribution'}
+            {'name': 'default', 'qcode': 'default', 'scheme': 'distribution'},
+            {'name': 'Greece', 'qcode': 'country_grc', 'scheme': 'country',
+             'translations': {'name': {'nl': 'Griekenland', 'fr': 'Grèce'}}},
+            {'name': 'Turkey', 'qcode': 'country_tur', 'scheme': 'country',
+             'translations': {'name': {'nl': 'Turkije', 'fr': 'Turquie'}}},
         ]
         expected_subjects.sort(key=lambda i: i['name'])
         self.assertEqual(item["subject"], expected_subjects)

--- a/server/tests/io/feed_parsers/belga_efe_newsml_1_2_test.py
+++ b/server/tests/io/feed_parsers/belga_efe_newsml_1_2_test.py
@@ -40,7 +40,9 @@ class BelgaEFENewsMLOneTestCase(BelgaTestCase):
             {'qcode': '01026000', 'name': 'mass media', 'scheme': 'iptc_subject_codes'},
             {'name': 'News', 'qcode': 'News', 'scheme': 'news_item_types'},
             {'name': 'EFE', 'qcode': 'EFE', 'scheme': 'credits'},
-            {'name': 'default', 'qcode': 'default', 'scheme': 'distribution'}
+            {'name': 'default', 'qcode': 'default', 'scheme': 'distribution'},
+            {'name': 'India', 'qcode': 'country_ind', 'scheme': 'country',
+             'translations': {'name': {'fr': 'Inde', 'nl': 'India'}}},
         ]
         expected_subjects.sort(key=lambda i: i['name'])
         self.assertEqual(item["slugline"], None)

--- a/server/tests/io/feed_parsers/belga_kyodo_newsml_1_2_test.py
+++ b/server/tests/io/feed_parsers/belga_kyodo_newsml_1_2_test.py
@@ -32,6 +32,15 @@ class BelgaKyodoNewsMLTestCase(BelgaTestCase):
         self.assertEqual(item['type'], 'text')
         self.assertEqual(item['firstcreated'].isoformat(), '2019-07-23T20:21:19+09:00')
         self.assertEqual(item['versioncreated'].isoformat(), '2019-07-23T20:21:19+09:00')
+        self.assertEqual(item['subject'], [
+            {'name': 'News', 'qcode': 'News', 'scheme': 'news_item_types'},
+            {'name': 'no', 'qcode': 'no', 'scheme': 'essential'},
+            {'name': 'no', 'qcode': 'no', 'scheme': 'equivalents_list'},
+            {'name': 'France', 'qcode': 'country_fra', 'scheme': 'country', 
+             'translations': {'name': {'fr': 'France', 'nl': 'Frankrijk'}}},
+            {'name': 'NEWS/GENERAL', 'parent': 'NEWS', 'qcode': 'NEWS/GENERAL', 'scheme': 'services-products'},
+            {'name': 'default', 'qcode': 'default', 'scheme': 'distribution'},
+        ])
         body_html = (
             "<p>     Former Chinese Premier Li Peng, who led a military crackdown on the pro-democracy movement at"
             " Beijing's Tiananmen Square in 1989, died Monday of illness in the capital, the official Xinhua"

--- a/server/tests/io/feed_parsers/belga_kyodo_newsml_1_2_test.py
+++ b/server/tests/io/feed_parsers/belga_kyodo_newsml_1_2_test.py
@@ -36,7 +36,7 @@ class BelgaKyodoNewsMLTestCase(BelgaTestCase):
             {'name': 'News', 'qcode': 'News', 'scheme': 'news_item_types'},
             {'name': 'no', 'qcode': 'no', 'scheme': 'essential'},
             {'name': 'no', 'qcode': 'no', 'scheme': 'equivalents_list'},
-            {'name': 'France', 'qcode': 'country_fra', 'scheme': 'country', 
+            {'name': 'France', 'qcode': 'country_fra', 'scheme': 'country',
              'translations': {'name': {'fr': 'France', 'nl': 'Frankrijk'}}},
             {'name': 'NEWS/GENERAL', 'parent': 'NEWS', 'qcode': 'NEWS/GENERAL', 'scheme': 'services-products'},
             {'name': 'default', 'qcode': 'default', 'scheme': 'distribution'},

--- a/server/tests/io/feed_parsers/belga_kyodo_newsml_1_2_test.py
+++ b/server/tests/io/feed_parsers/belga_kyodo_newsml_1_2_test.py
@@ -33,13 +33,13 @@ class BelgaKyodoNewsMLTestCase(BelgaTestCase):
         self.assertEqual(item['firstcreated'].isoformat(), '2019-07-23T20:21:19+09:00')
         self.assertEqual(item['versioncreated'].isoformat(), '2019-07-23T20:21:19+09:00')
         self.assertEqual(item['subject'], [
-            {'name': 'News', 'qcode': 'News', 'scheme': 'news_item_types'},
-            {'name': 'no', 'qcode': 'no', 'scheme': 'essential'},
-            {'name': 'no', 'qcode': 'no', 'scheme': 'equivalents_list'},
             {'name': 'France', 'qcode': 'country_fra', 'scheme': 'country',
              'translations': {'name': {'fr': 'France', 'nl': 'Frankrijk'}}},
             {'name': 'NEWS/GENERAL', 'parent': 'NEWS', 'qcode': 'NEWS/GENERAL', 'scheme': 'services-products'},
+            {'name': 'News', 'qcode': 'News', 'scheme': 'news_item_types'},
             {'name': 'default', 'qcode': 'default', 'scheme': 'distribution'},
+            {'name': 'no', 'qcode': 'no', 'scheme': 'essential'},
+            {'name': 'no', 'qcode': 'no', 'scheme': 'equivalents_list'},
         ])
         body_html = (
             "<p>     Former Chinese Premier Li Peng, who led a military crackdown on the pro-democracy movement at"

--- a/server/tests/io/feed_parsers/belga_tass_newsml_1_2_test.py
+++ b/server/tests/io/feed_parsers/belga_tass_newsml_1_2_test.py
@@ -11,14 +11,16 @@
 
 import os
 from lxml import etree
-from superdesk.tests import TestCase
+
 from belga.io.feed_parsers.belga_tass_newsml_1_2 import BelgaTASSNewsMLOneFeedParser
+from . import BelgaTestCase
 
 
-class BelgaTASSNewsMLOneTestCase(TestCase):
+class BelgaTASSNewsMLOneTestCase(BelgaTestCase):
     filename = 'tass_belga.xml'
 
     def setUp(self):
+        super().setUp()
         dirname = os.path.dirname(os.path.realpath(__file__))
         fixture = os.path.normpath(os.path.join(dirname, '../fixtures', self.filename))
         provider = {'name': 'test'}
@@ -41,7 +43,7 @@ class BelgaTASSNewsMLOneTestCase(TestCase):
             {'name': 'normal', 'qcode': 'normal', 'scheme': 'link_type'},
             {'name': 'default', 'qcode': 'default', 'scheme': 'distribution'},
             {'name': 'News', 'qcode': 'News', 'scheme': 'news_item_types'},
-            {'name': 'Russian Federation', 'qcode': 'country_rus',
+            {'name': 'Russian Federation', 'qcode': 'country_rus', 'scheme': 'country',
              'translations': {'name': {'nl': 'Rusland', 'fr': 'Russie'}}},
         ]
         expected_subjects.sort(key=lambda i: i['scheme'])
@@ -56,7 +58,7 @@ class BelgaTASSNewsMLOneTestCase(TestCase):
         self.assertEqual(item["headline"], "Kremlin has 'negative reaction' to upcoming EU sanctions")
         self.assertEqual(item["language"], "en")
         self.assertEqual(item["descriptive_guid"], "16AAC34CE1C503AE4325838900396A95")
-        self.assertEqual(item["extra"], {'how_present': 'Origin', 'city': 'MOSCOW'})
+        self.assertEqual(item["extra"], {'how_present': 'Origin', 'country': 'RUS', 'city': 'MOSCOW'})
         self.assertEqual(item["type"], "text")
         self.assertEqual(item["mimetype"], "text/vnd.IPTC.NITF")
         self.assertEqual(item["slugline"], None)

--- a/server/tests/io/feed_parsers/belga_tass_newsml_1_2_test.py
+++ b/server/tests/io/feed_parsers/belga_tass_newsml_1_2_test.py
@@ -40,7 +40,9 @@ class BelgaTASSNewsMLOneTestCase(TestCase):
             {'name': 'TASS', 'qcode': 'TASS', 'scheme': 'credits'},
             {'name': 'normal', 'qcode': 'normal', 'scheme': 'link_type'},
             {'name': 'default', 'qcode': 'default', 'scheme': 'distribution'},
-            {'name': 'News', 'qcode': 'News', 'scheme': 'news_item_types'}
+            {'name': 'News', 'qcode': 'News', 'scheme': 'news_item_types'},
+            {'name': 'Russian Federation', 'qcode': 'country_rus',
+             'translations': {'name': {'nl': 'Rusland', 'fr': 'Russie'}}},
         ]
         expected_subjects.sort(key=lambda i: i['scheme'])
         self.assertEqual(item["subject"], expected_subjects)

--- a/server/tests/io/fixtures/kyodo_newsml_1_2_belga.xml
+++ b/server/tests/io/fixtures/kyodo_newsml_1_2_belga.xml
@@ -52,6 +52,10 @@
 					<SubjectMatter FormalName="14023000" Scheme="IptcSubjectCodes"/>
 					<SubjectMatter FormalName="11006000" Scheme="IptcSubjectCodes"/>
 				</SubjectCode>
+				<Location HowPresent="Origin">
+					<Property FormalName="Country" Value="FRA"/>
+					<Property FormalName="City" Value="Paris"/>
+				</Location>
 			</DescriptiveMetadata>
 			<Metadata>
 				<Catalog Href="../catalogKWS/KWSMasterCatalog_v1.0.xml"/>

--- a/server/tests/io/fixtures/tass_belga.xml
+++ b/server/tests/io/fixtures/tass_belga.xml
@@ -29,7 +29,7 @@ www.itar-tass.com
 <DescriptiveMetada>
 <Language FormalName="en"/>
 <guid>16AAC34CE1C503AE4325838900396A95</guid>
-<Location HowPresent="Origin"><Property FormalName="City" Value="MOSCOW"/></Location></DescriptiveMetada>
+<Location HowPresent="Origin"><Property FormalName="Country" Value="RUS"/><Property FormalName="City" Value="MOSCOW"/></Location></DescriptiveMetada>
 <ContentItem><MediaType FormalName="ComplexData" /><MimeType FormalName="text/vnd.IPTC.NITF" />
 <DataContent><nitf><body><body.head><hedline>
 <hl1>Kremlin has 'negative reaction' to upcoming EU sanctions</hl1>


### PR DESCRIPTION
Add multilingual country support for following NewsML format:
- AFP
- DPA (xml)
- EFE
- Kyoudo

Following format uses two character country code so it will always empty:
- [ANP](https://github.com/idsvn/superdesk-belga/blob/SDBELGA-266/server/tests/io/fixtures/anp_belga.xml#L58)
- [ATS](https://github.com/idsvn/superdesk-belga/blob/SDBELGA-266/server/tests/io/fixtures/ats_newsml_1_2_belga.xml#L64)

For ATS, DPA text, from what we saw, we currently don't parse country
For TASS, if we use [NewsComponent/NewsComponent](https://github.com/idsvn/superdesk-belga/blob/SDBELGA-266/server/belga/io/feed_parsers/belga_tass_newsml_1_2.py#L76), `vocabularies` service for `country` will return None, @ride90 Could you give us your opinion on this?
SDBELGA-266