### PR TITLE
[SDBELGA-263] Fix ingest error on importing AFP without headline

### DIFF
--- a/server/tests/io/feed_parsers/belga_afp_newsml_1_2_test.py
+++ b/server/tests/io/feed_parsers/belga_afp_newsml_1_2_test.py
@@ -82,8 +82,8 @@ class BelgaAFPNewsMLOneTestCase(BelgaTestCase):
         self.assertEqual(item["characteristics"], {'size_bytes': '1620', 'word_count': '269'})
         expected_body = \
             (
-
-                "\n<p>Le procès de deux anciens fonctionnaires de la police aux frontières (PAF) de l'aéroport parisie"
+                "\n<p><br/></p><p>   </p>"
+                "\n<p> Le procès de deux anciens fonctionnaires de la police aux frontières (PAF) de l'aéroport parisie"
                 "n Roissy-Charles de Gaulle, accusés d'avoir facilité l'importation de cocaïne de retour de Républiqu"
                 "e dominicaine, s'est ouvert lundi devant un tribunal à Paris. </p>\n<p>Clément Geisse, 42 ans, et Chr"
                 'istophe Peignelin, 56 ans, comparaissent notamment pour importation de stupéfiants en bande organisé'

--- a/server/tests/io/fixtures/afp_belga.xml
+++ b/server/tests/io/fixtures/afp_belga.xml
@@ -108,7 +108,8 @@
 <nitf>
 <body>
 <body.content>
-<p>Le procès de deux anciens fonctionnaires de la police aux frontières (PAF) de l'aéroport parisien Roissy-Charles de Gaulle, accusés d'avoir facilité l'importation de cocaïne de retour de République dominicaine, s'est ouvert lundi devant un tribunal à Paris. </p>
+<p><br/></p><p>   </p>
+<p> Le procès de deux anciens fonctionnaires de la police aux frontières (PAF) de l'aéroport parisien Roissy-Charles de Gaulle, accusés d'avoir facilité l'importation de cocaïne de retour de République dominicaine, s'est ouvert lundi devant un tribunal à Paris. </p>
 <p>Clément Geisse, 42 ans, et Christophe Peignelin, 56 ans, comparaissent notamment pour importation de stupéfiants en bande organisée - un crime passible de trente ans de réclusion - et corruption passive, devant la cour d'assises spéciale, composée de magistrats professionnels, sans jury. </p>
 <p>Les deux hommes aux cheveux bruns coupés courts, l'un la mâchoire carrée, l'autre le visage émacié, ont pénétré dans le box des accusés, déclinant d'un ton grave leur identité et leur ancienne profession.</p>
 <p>Ils ont reconnu avoir permis sept à neuf passages de "mules" aux valises chargées de cocaïne en les aidant à contourner les contrôles de l'aéroport de Roissy, entre 2010 et le 25 janvier 2015, date de leur interpellation. Ils venaient de tenter de faire sortir deux valises contenant chacune 20 kilos de drogue. </p>


### PR DESCRIPTION
This issue is related to https://github.com/superdesk/superdesk-belga/pull/65 (SDBELGA-181), where we will use first line of body as its headline.
If we ingest AFP file with the following body, it will fail
```xml
<body.content><p>example</p><p>abc</p></body.content>
```
Because we assume that the body will _always_ contains newline break, as such, we pass to XML parser two node **without parent**

In addition to fixing above issues, we also add some fixes:
- Handle `h2` tag (Superdesk client only support this header in body), though we saw that most of provided files had its body be wrapped in `p` tag
- Remove linebreak (`<p><br/></p>`) and empty tag (`<p>   </p>` or `<p></p>`)

SDBELGA-263