### PR TITLE
fix belga image auth for complex queries

### DIFF
--- a/server/belga/search_providers.py
+++ b/server/belga/search_providers.py
@@ -57,10 +57,11 @@ class BelgaImageSearchProvider(superdesk.SearchProvider):
         if self.provider.get('config') and self.provider['config'].get('username'):
             self.auth()
 
-    def auth_headers(self, url, secret=None):
+    def auth_headers(self, url, secret=None, nonce=None):
         if not secret and not self._id_token:
             return {}
-        nonce = uuid.uuid4().hex
+        if not nonce:
+            nonce = uuid.uuid4().hex
         return {
             'X-Date': nonce,
             'X-Identification': '{}:{}'.format(
@@ -121,7 +122,7 @@ class BelgaImageSearchProvider(superdesk.SearchProvider):
 
     def api_get(self, endpoint, params):
         url = requests.Request('GET', 'http://example.com/' + endpoint, params=params).prepare().path_url
-        headers = self.auth_headers(url)
+        headers = self.auth_headers(url.replace('%2C', ','))  # decode spaces
         resp = self.session.get(self.url(url), headers=headers)
         resp.raise_for_status()
         return resp.json()

--- a/server/tests/belga_image_test.py
+++ b/server/tests/belga_image_test.py
@@ -150,3 +150,21 @@ class BelgaImageTestCase(unittest.TestCase):
                 ).hexdigest(),
             )
         )
+
+    def test_auth_search_criteria(self):
+        provider = BelgaImageSearchProvider({})
+        provider.provider['config'] = {'username': 'test'}
+        provider._id_token = "25222473406"
+        provider._auth_token = "339824739329"
+        nonce = "Thu, 13 Feb 2020 13:19:05 GMT"
+        url = (
+            "/searchImages?s=0&l=200&t="
+            "(test) AND (BELGAPORTRAIT OR HEADSHOT)&r=2&c=AFP,BELGA&h=news&l=BELGAPORTRAIT,HEADSHOT"
+        )
+        headers = provider.auth_headers(url, nonce=nonce)
+        self.assertEqual(
+            "test:30f35157e8da2015c069af6a814ab30ee0121b2ce22d4f060140e32cce013af6",
+            headers['X-Identification'])
+        self.assertEqual(
+            "test:da70d29ee4703023f27b6af5cbad9fb267de50e02332ec4359d860c5d5b98253",
+            headers['X-Authorization'])


### PR DESCRIPTION
seems like the server uses decoded url to check
signature so it must match

SDBELGA-298