### PR TITLE
[SDBELGA-305] Fix Tips does not display desk after fetched

### DIFF
--- a/server/belga/io/feed_parsers/belga_newsml_1_2.py
+++ b/server/belga/io/feed_parsers/belga_newsml_1_2.py
@@ -223,7 +223,10 @@ class BelgaNewsMLOneFeedParser(BaseBelgaNewsMLOneFeedParser):
             element = newsident_el.find('RevisionId')
             if element is not None and element.text:
                 # version
-                identification['version'] = int(element.text)
+                version = int(element.text)
+                if version == 0:
+                    version = 1
+                identification['version'] = version
 
             element = newsident_el.find('PublicIdentifier')
             if element is not None:

--- a/server/tests/io/feed_parsers/belga_remote_newsml_1_2_test.py
+++ b/server/tests/io/feed_parsers/belga_remote_newsml_1_2_test.py
@@ -35,7 +35,7 @@ class BelgaRemoteNewsMLOneTestCase(TestCase):
         self.assertEqual(item["provider_id"], "belga.be")
         self.assertEqual(item["date_id"], "20190603T160217")
         self.assertEqual(item["item_id"], "0")
-        self.assertEqual(item["version"], 0)
+        self.assertEqual(item["version"], 1)
         self.assertEqual(item["public_identifier"], "urn:newsml:www.belga.be")
         self.assertEqual(item["subject"], [{'name': 'NEWS', 'qcode': 'NEWS', 'scheme': 'news_item_types'},
                                            {'name': 'BIN/ALG', 'qcode': 'BIN/ALG', 'scheme': 'services-products',

--- a/server/tests/io/feed_parsers/belga_tip_newsml_1_2_test.py
+++ b/server/tests/io/feed_parsers/belga_tip_newsml_1_2_test.py
@@ -35,7 +35,7 @@ class BelgaTipNewsMLOneTestCase(TestCase):
         self.assertEqual(item["provider_id"], "belga.be")
         self.assertEqual(item["date_id"], "20190928T074132")
         self.assertEqual(item["item_id"], None)
-        self.assertEqual(item["version"], 0)
+        self.assertEqual(item["version"], 1)
         self.assertEqual(item["public_identifier"], "urn:newsml:www.belga.be")
         self.assertEqual(
             item["subject"], [


### PR DESCRIPTION
When using ingest routing, Tips ingest (and Belga NewsML 1.2) does not display desks name, only **fetched in**

Most of TIPS files have version 0, so it is [excluded](https://github.com/superdesk/superdesk-core/blob/develop/apps/search/__init__.py#L77) from `search` service, the UI is using `search` service to fetch desk of ingested item, hence the bug.

SDBELGA-305