### PR TITLE
fix brief internal destination macro

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: python
 
-python: "3.5"
+python: "3.6"
 
 services:
     - mongodb

--- a/server/belga/__init__.py
+++ b/server/belga/__init__.py
@@ -1,0 +1,5 @@
+import logging
+
+# set logging level for belga logger
+logger = logging.getLogger(__name__)
+logger.setLevel(logging.INFO)


### PR DESCRIPTION
- ignore items with non TEXT profile and with long body
- fix time selected when de-scheduling the item
- schedule new item 30m after publishing text in case it's scheduled
- handle validation error for newly create items to avoid client error

SDBELGA-315 SDBELGA-316 SDBELGA-318 SDBELGA-319