### PR TITLE
implement unsetting of user when sent to incoming stage

### DIFF
--- a/server/belga/macros/unmark_from_user.py
+++ b/server/belga/macros/unmark_from_user.py
@@ -1,0 +1,19 @@
+
+import logging
+
+logger = logging.getLogger(__name__)
+
+
+def callback(item, **kwargs):
+    if item.get('marked_for_user'):
+        orig = item.copy()
+        item['previous_marked_user'] = item['marked_for_user']
+        item['marked_for_user'] = None
+        logger.info('unset marked for user for item %s', item['guid'])
+    return item
+
+
+action_type = 'direct'
+access_type = 'backend'
+name = 'unmark_from_user'
+label = "Unmark from User"

--- a/server/belga/unmark_user_when_moved_to_incoming_stage.py
+++ b/server/belga/unmark_user_when_moved_to_incoming_stage.py
@@ -1,0 +1,29 @@
+
+import logging
+
+from superdesk import get_resource_service
+from superdesk.signals import item_move
+
+logger = logging.getLogger(__name__)
+
+
+def unmark_user(sender, item, original):
+    marked_for_user = item.get('marked_for_user', original.get('marked_for_user'))
+    if not marked_for_user:
+        logger.debug('mark for user is empty')
+        return
+
+    try:
+        new_stage = item['task']['stage']
+        desk = get_resource_service('desks').find_one(req=None, _id=item['task']['desk'])
+        if desk['incoming_stage'] == new_stage:
+            item['previous_marked_user'] = marked_for_user
+            item['marked_for_user'] = None
+            logger.info('unmarked user on item %s', item['guid'])
+    except KeyError as err:
+        logger.error('key error %s', err)
+        return
+
+
+def init_app(_app):
+    item_move.connect(unmark_user)

--- a/server/settings.py
+++ b/server/settings.py
@@ -29,6 +29,7 @@ INSTALLED_APPS.extend([
     'belga.publish',
     'belga.macros',
     'belga.update',
+    'belga.unmark_user_when_moved_to_incoming_stage',
 ])
 
 SECRET_KEY = env('SECRET_KEY', '')

--- a/server/tests/macros/unmark_from_user_test.py
+++ b/server/tests/macros/unmark_from_user_test.py
@@ -12,7 +12,7 @@ class UnmarkFromUserTestCase(unittest.TestCase):
         assert hasattr(macro, 'callback')
 
     def test_callback(self):
-        item = {'marked_for_user': 'foo'}
+        item = {'marked_for_user': 'foo', 'guid': 'test'}
         orig = item.copy()
         item = macro.callback(item)
         self.assertIsNone(item['marked_for_user'])

--- a/server/tests/macros/unmark_from_user_test.py
+++ b/server/tests/macros/unmark_from_user_test.py
@@ -1,0 +1,19 @@
+
+import unittest
+
+from belga.macros import unmark_from_user as macro
+
+
+class UnmarkFromUserTestCase(unittest.TestCase):
+
+    def test_metadata(self):
+        assert hasattr(macro, 'name')
+        assert hasattr(macro, 'label')
+        assert hasattr(macro, 'callback')
+
+    def test_callback(self):
+        item = {'marked_for_user': 'foo'}
+        orig = item.copy()
+        item = macro.callback(item)
+        self.assertIsNone(item['marked_for_user'])
+        self.assertEqual(item['previous_marked_user'], 'foo')


### PR DESCRIPTION
there is both macro and a signal handler, so it will work
on inline stage out of the box and if needed it can be configured
via macro for other stages.

requires https://github.com/superdesk/superdesk-core/pull/1815

SDBELGA-314