### PR TITLE
[SDBELGA-351] Fix can't drag belga360 item to related article

### DIFF
--- a/server/belga/search_providers.py
+++ b/server/belga/search_providers.py
@@ -277,9 +277,10 @@ class Belga360ArchiveSearchProvider(superdesk.SearchProvider):
         created = get_datetime(datetime.datetime.now())
         return {
             'type': 'text',
-            'mimetype': 'application/vnd.belga.360archive',
+            'mimetype': 'application/superdesk.vnd.belga.360archive',
             'pubstatus': 'usable',
             '_id': guid,
+            'state': 'published',
             'guid': guid,
             'headline': get_text(data['headLine']),
             'slugline': get_text(data['topic']),

--- a/server/tests/belga_360_archive_test.py
+++ b/server/tests/belga_360_archive_test.py
@@ -67,8 +67,9 @@ class Belga360ArchiveTestCase(unittest.TestCase):
         item = self.provider.format_list_item(get_belga360_item())
         guid = 'urn:belga.be:360archive:39670442'
         self.assertEqual(item['type'], 'text')
-        self.assertEqual(item['mimetype'], 'application/vnd.belga.360archive')
+        self.assertEqual(item['mimetype'], 'application/superdesk.vnd.belga.360archive')
         self.assertEqual(item['_id'], guid)
+        self.assertEqual(item['state'], 'published')
         self.assertEqual(item['guid'], guid)
         self.assertEqual(item['extra']['bcoverage'], guid)
         self.assertEqual(item['headline'], 'Lorem ipsum dolor sit amet, consectetur adipiscing elit.')


### PR DESCRIPTION
- Fix can't drag Belga 360 Archive item to **related article**, mainly because of [getSuperdeskType](https://github.com/superdesk/superdesk-client-core/blob/develop/scripts/core/utils.ts#L33) which is used in [RelatedItemsDirective](https://github.com/superdesk/superdesk-client-core/blob/develop/scripts/apps/relations/directives/RelatedItemsDirective.ts#L114)
- Change item's state to `published`


SDBELGA-351