### PR TITLE
[SDBELGA-365] Fix wrong remote attachments path

### DIFF
--- a/server/belga/io/feed_parsers/belga_remote_newsml_1_2.py
+++ b/server/belga/io/feed_parsers/belga_remote_newsml_1_2.py
@@ -242,7 +242,7 @@ class BelgaRemoteNewsMLOneFeedParser(BelgaNewsMLOneFeedParser):
             file_service = FileFeedingService()
             # move processed attachments to the same folder with XML
             file_dir = os.path.dirname(file_dir)
-            file_service.move_file(file_dir, '/attachments/' + filename, self.provider)
+            file_service.move_file(file_dir, 'attachments/' + filename, self.provider)
 
 
 register_feed_parser(BelgaRemoteNewsMLOneFeedParser.NAME, BelgaRemoteNewsMLOneFeedParser())


### PR DESCRIPTION
```python
os.path.join('/home/ids', '/attachments/image.png') => /attachments/image.png
os.path.join('/home/ids', 'attachments/image.png') => /home/ids/attachments/image.png
```
Used in https://github.com/superdesk/superdesk-core/blob/develop/superdesk/io/feeding_services/file_service.py#L152

SDBELGA-365