### PR TITLE
Add video thumbnail (preview picture) to Belga NewsML output

### DIFF
--- a/server/belga/publish/belga_newsml_1_2.py
+++ b/server/belga/publish/belga_newsml_1_2.py
@@ -224,7 +224,7 @@ class BelgaNewsML12Formatter(NewsML12Formatter):
         """
 
         news_management = SubElement(newsitem, 'NewsManagement')
-        SubElement(news_management, 'NewsItemType', {'FormalName': 'News'})
+        SubElement(news_management, 'NewsItemType', {'FormalName': 'NEWS'})
         SubElement(
             news_management, 'FirstCreated'
         ).text = self._get_formatted_datetime(self._current_item.get('firstcreated'))

--- a/server/belga/publish/belga_newsml_1_2.py
+++ b/server/belga/publish/belga_newsml_1_2.py
@@ -642,6 +642,25 @@ class BelgaNewsML12Formatter(NewsML12Formatter):
         )
         self._format_media_contentitem(newscomponent_3_level, rendition=video['renditions']['original'])
 
+        # video image thumbnail
+        for role, key in (('Image', 'viewImage'), ('Thumbnail', 'thumbnail')):
+            if key not in video['renditions']:
+                continue
+            newscomponent_3_level = SubElement(newscomponent_2_level, 'NewsComponent')
+            if video.get(GUID_FIELD):
+                newscomponent_3_level.attrib['Duid'] = video.get(GUID_FIELD)
+            if video.get('language'):
+                newscomponent_3_level.attrib[XML_LANG] = video.get('language')
+
+            SubElement(newscomponent_3_level, 'Role', {'FormalName': role})
+            SubElement(
+                SubElement(newscomponent_3_level, 'DescriptiveMetadata'),
+                'Property',
+                {'FormalName': 'ComponentClass', 'Value': 'Image'}
+            )
+
+            self._format_media_contentitem(newscomponent_3_level, rendition=video['renditions'][key])
+
     def _format_attachment(self, newscomponent_1_level, attachment):
         """
         Creates a `<NewsComponent>` of a 2nd level with file attached to the item.

--- a/server/tests/publish/belga_newsml_1_2_picture_tests.py
+++ b/server/tests/publish/belga_newsml_1_2_picture_tests.py
@@ -262,7 +262,7 @@ class BelgaNewsML12FormatterVideoTest(TestCase):
         newsitemtype = self.newsml.xpath('NewsItem/NewsManagement/NewsItemType')[0]
         self.assertDictEqual(
             dict(newsitemtype.attrib),
-            {'FormalName': 'News'}
+            {'FormalName': 'NEWS'}
         )
         self.assertIsNone(newsitemtype.text)
         self.assertEqual(

--- a/server/tests/publish/belga_newsml_1_2_text_tests.py
+++ b/server/tests/publish/belga_newsml_1_2_text_tests.py
@@ -1019,7 +1019,7 @@ class BelgaNewsML12FormatterTextTest(TestCase):
         newsitemtype = self.newsml.xpath('NewsItem/NewsManagement/NewsItemType')[0]
         self.assertDictEqual(
             dict(newsitemtype.attrib),
-            {'FormalName': 'News'}
+            {'FormalName': 'NEWS'}
         )
         self.assertIsNone(newsitemtype.text)
         self.assertEqual(

--- a/server/tests/publish/belga_newsml_1_2_video_tests.py
+++ b/server/tests/publish/belga_newsml_1_2_video_tests.py
@@ -73,6 +73,20 @@ class BelgaNewsML12FormatterVideoTest(TestCase):
                 "href": "http://localhost:5000/api/upload-raw/video_1.mp4",
                 "media": "video_1",
                 "mimetype": "video/mp4"
+            },
+            "viewImage": {
+                "href": "http://localhost:5000/api/upload-raw/pic_1.jpg",
+                "media": "pic_1",
+                "mimetype": "image/jpeg",
+                "width": 200,
+                "height": 133
+            },
+            "thumbnail": {
+                "href": "http://localhost:5000/api/upload-raw/pic_2.jpg",
+                "media": "pic_2",
+                "mimetype": "image/jpeg",
+                "width": 1920,
+                "height": 1280
             }
         },
         "mimetype": "video/mp4",
@@ -207,6 +221,22 @@ class BelgaNewsML12FormatterVideoTest(TestCase):
                 'content_type': 'video/mp4',
                 'metadata': {
                     'length': 12
+                }
+            },
+            {
+                '_id': 'pic_1',
+                'content': BytesIO(b'pic_one_content'),
+                'content_type': 'image/jpeg',
+                'metadata': {
+                    'length': 10
+                }
+            },
+            {
+                '_id': 'pic_2',
+                'content': BytesIO(b'pic_two_content'),
+                'content_type': 'image/jpeg',
+                'metadata': {
+                    'length': 10
                 }
             },
         )
@@ -364,7 +394,7 @@ class BelgaNewsML12FormatterVideoTest(TestCase):
             sizeinbytes.text,
             '5'
         )
-        # NewsML -> NewsItem -> NewsComponent -> NewsComponent -> NewsComponent
+        # NewsML -> NewsItem -> NewsComponent -> NewsComponent -> NewsComponent(Clip)
         contentitem = newscomponent_2_level.xpath(
             'NewsComponent/Role[@FormalName="Clip"]/ancestor::NewsComponent/ContentItem'
         )[0]
@@ -385,4 +415,48 @@ class BelgaNewsML12FormatterVideoTest(TestCase):
         self.assertEqual(
             mimetype.attrib['FormalName'],
             'video/mp4'
+        )
+        # NewsML -> NewsItem -> NewsComponent -> NewsComponent -> NewsComponent(Image)
+        contentitem = newscomponent_2_level.xpath(
+            'NewsComponent/Role[@FormalName="Image"]/ancestor::NewsComponent/ContentItem'
+        )[0]
+        self.assertEqual(
+            contentitem.attrib['Href'],
+            'urn:www.belga.be:superdesk:tst:pic_1'
+        )
+        _format = newscomponent_2_level.xpath(
+            'NewsComponent/Role[@FormalName="Image"]/ancestor::NewsComponent/ContentItem/Format'
+        )[0]
+        self.assertEqual(
+            _format.attrib['FormalName'],
+            'Jpg'
+        )
+        mimetype = newscomponent_2_level.xpath(
+            'NewsComponent/Role[@FormalName="Image"]/ancestor::NewsComponent/ContentItem/MimeType'
+        )[0]
+        self.assertEqual(
+            mimetype.attrib['FormalName'],
+            'image/jpeg'
+        )
+        # NewsML -> NewsItem -> NewsComponent -> NewsComponent -> NewsComponent(Thumbnail)
+        contentitem = newscomponent_2_level.xpath(
+            'NewsComponent/Role[@FormalName="Thumbnail"]/ancestor::NewsComponent/ContentItem'
+        )[0]
+        self.assertEqual(
+            contentitem.attrib['Href'],
+            'urn:www.belga.be:superdesk:tst:pic_2'
+        )
+        _format = newscomponent_2_level.xpath(
+            'NewsComponent/Role[@FormalName="Thumbnail"]/ancestor::NewsComponent/ContentItem/Format'
+        )[0]
+        self.assertEqual(
+            _format.attrib['FormalName'],
+            'Jpg'
+        )
+        mimetype = newscomponent_2_level.xpath(
+            'NewsComponent/Role[@FormalName="Thumbnail"]/ancestor::NewsComponent/ContentItem/MimeType'
+        )[0]
+        self.assertEqual(
+            mimetype.attrib['FormalName'],
+            'image/jpeg'
         )

--- a/server/tests/publish/belga_newsml_1_2_video_tests.py
+++ b/server/tests/publish/belga_newsml_1_2_video_tests.py
@@ -298,7 +298,7 @@ class BelgaNewsML12FormatterVideoTest(TestCase):
         newsitemtype = self.newsml.xpath('NewsItem/NewsManagement/NewsItemType')[0]
         self.assertDictEqual(
             dict(newsitemtype.attrib),
-            {'FormalName': 'News'}
+            {'FormalName': 'NEWS'}
         )
         self.assertIsNone(newsitemtype.text)
         self.assertEqual(


### PR DESCRIPTION
SDBELGA-367 Add video thumbnail (preview picture) to Belga NewsML output
SDBELGA-375 NewsItemType field in Belga NewsML export must have value "NEWS" instead of "News"
