### PR TITLE
[SBELGA-271][SDBELGA-288] Belga Archive Advanced Search

### DIFF
--- a/client/belga/360archive/BelgaSearchPanelController.ts
+++ b/client/belga/360archive/BelgaSearchPanelController.ts
@@ -26,18 +26,10 @@ export default class BelgaSearchPanelController {
 
     this.periods = [
       { name: "Whenever", id: "" },
-      { name: "Last 4 hours", id: "last4h" },
-      { name: "Last 8 hours", id: "last8h" },
-      { name: "Today", id: "today" },
-      { name: "Yesterday", id: "yesterday" },
       { name: "Last 24 hours", id: "day" },
-      { name: "Last 48 hours", id: "last48h" },
-      { name: "Last 72 hours", id: "last74h" },
-      { name: "Last week", id: "week1" },
-      { name: "Last 2 weeks", id: "week2" },
+      { name: "Last week", id: "week" },
       { name: "Last month", id: "month" },
       { name: "Last year", id: "year" },
-      { name: "Last 2 years", id: "year2" }
     ];
   }
 }

--- a/client/belga/360archive/BelgaSearchPanelController.ts
+++ b/client/belga/360archive/BelgaSearchPanelController.ts
@@ -18,10 +18,10 @@ export default class BelgaSearchPanelController {
     ];
 
     this.types = [
-      { name: "alert", id: "alert" },
-      { name: "text", id: "text" },
-      { name: "brief", id: "brief" },
-      { name: "short", id: "short" }
+      { name: "Alert", id: "Alert" },
+      { name: "Text", id: "Text" },
+      { name: "Brief", id: "Brief" },
+      { name: "Short", id: "Short" }
     ];
 
     this.periods = [

--- a/client/belga/360archive/views/search-panel.html
+++ b/client/belga/360archive/views/search-panel.html
@@ -1,12 +1,5 @@
 <fieldset ng-controller="BelgaSearchPanelController as searchPanel">
     <div class="field">
-        <label for="search-headline">{{:: 'Headline' | translate}}</label>
-        <div class="control">
-            <input type="text" id="search-headline" ng-model="params.headline" tabindex="1">
-        </div>
-    </div>
-
-    <div class="field">
         <label class="search-label">Language</label>
         <select ng-model="params.languages">
             <option ng-repeat="language in searchPanel.languages" value="{{ language.id }}">{{ language.name }}</option>
@@ -24,6 +17,13 @@
         <label for="search-headline">{{:: 'Credits' | translate}}</label>
         <div class="control">
             <input type="text" id="search-credits" ng-model="params.credits" tabindex="1">
+        </div>
+    </div>
+
+    <div class="field">
+        <label for="search-headline">{{:: 'Sources' | translate}}</label>
+        <div class="control">
+            <input type="text" id="search-sources" ng-model="params.sources" tabindex="1">
         </div>
     </div>
 

--- a/client/belga/360archive/views/search-panel.html
+++ b/client/belga/360archive/views/search-panel.html
@@ -21,13 +21,6 @@
     </div>
 
     <div class="field">
-        <label for="search-headline">{{:: 'Sources' | translate}}</label>
-        <div class="control">
-            <input type="text" id="search-sources" ng-model="params.sources" tabindex="1">
-        </div>
-    </div>
-
-    <div class="field">
         <label class="search-label" translate>Period</label>
         <select ng-model="params.period">
             <option ng-repeat="period in searchPanel.periods" value="{{ period.id }}">{{ period.name }}</option>

--- a/server/belga/search_providers.py
+++ b/server/belga/search_providers.py
@@ -289,7 +289,7 @@ class Belga360ArchiveSearchProvider(superdesk.SearchProvider):
             return ''
 
     def _get_period(self, period):
-        today = arrow.now(BELGA_TZ)
+        today = arrow.now(superdesk.app.config['DEFAULT_TIMEZONE'])
         return {
             'fromDate': today.shift(**self.PERIODS.get(period)).format('YYYYMMDD'),
             'toDate': today.format('YYYYMMDD'),

--- a/server/belga/search_providers.py
+++ b/server/belga/search_providers.py
@@ -272,9 +272,13 @@ class Belga360ArchiveSearchProvider(superdesk.SearchProvider):
     def _get_abstract(self, item):
         return self._get_newscomponent(item, 'lead')
 
+    def _get_datetime(self, date=None):
+        if not date:
+            return get_datetime(date)
+        return get_datetime(date / 1000)
+
     def format_list_item(self, data):
         guid = '%s%d' % (self.GUID_PREFIX, data['newsObjectId'])
-        created = get_datetime(datetime.datetime.now())
         return {
             'type': 'text',
             'mimetype': 'application/superdesk.vnd.belga.360archive',
@@ -286,8 +290,8 @@ class Belga360ArchiveSearchProvider(superdesk.SearchProvider):
             'slugline': get_text(data['topic']),
             'name': get_text(data['name']),
             'description_text': get_text(data.get('description')),
-            'versioncreated': created,
-            'firstcreated': created,
+            'versioncreated': self._get_datetime(data.get('validateDate')),
+            'firstcreated': self._get_datetime(data.get('createDate')),
             'creditline': get_text(data['credit']),
             'source': get_text(data['source']),
             'language': get_text(data['language']),

--- a/server/tests/belga_360_archive_test.py
+++ b/server/tests/belga_360_archive_test.py
@@ -54,10 +54,20 @@ class Belga360ArchiveTestCase(unittest.TestCase):
         self.assertIsInstance(self.provider, superdesk.SearchProvider)
 
     def test_find_params(self):
+        params = {
+            'sources': 'belga',
+            'credits': 'afp',
+            'dates': {'start': '02/02/2020', 'end': '14/02/2020'},
+            'languages': 'en',
+            'types': 'Short',
+        }
         self.provider.session.get = MagicMock()
-        self.provider.find(self.query)
+        self.provider.find(self.query, params)
         url = self.provider.base_url + 'archivenewsobjects'
-        params = {'start': 50, 'pageSize': 50, 'searchText': 'test query'}
+        params = {
+            'start': 50, 'pageSize': 50, 'language': 'en', 'assetType': 'Short', 'credits': 'AFP',
+            'sources': 'BELGA', 'fromDate': '20200202', 'toDate': '20200214', 'searchText': 'test query',
+        }
         self.provider.session.get.assert_called_with(url, params=params)
 
     def test_format_list_item(self):

--- a/server/tests/belga_360_archive_test.py
+++ b/server/tests/belga_360_archive_test.py
@@ -6,6 +6,7 @@ import arrow
 from flask import json
 from httmock import all_requests, HTTMock
 from unittest.mock import MagicMock
+from superdesk.factory import get_app as get_sd_app
 
 from belga.search_providers import Belga360ArchiveSearchProvider, get_datetime
 
@@ -120,7 +121,8 @@ class Belga360ArchiveTestCase(unittest.TestCase):
 
     def test_get_periods(self):
         arrow.now = MagicMock(return_value=arrow.get('2020-02-14'))
-        day_period = self.provider._get_period('day')
+        with get_sd_app().app_context():
+            day_period = self.provider._get_period('day')
         self.assertEqual(day_period['fromDate'], '20200213')
         self.assertEqual(day_period['toDate'], '20200214')
 

--- a/server/tests/belga_360_archive_test.py
+++ b/server/tests/belga_360_archive_test.py
@@ -6,7 +6,7 @@ from flask import json
 from httmock import all_requests, HTTMock
 from unittest.mock import MagicMock
 
-from belga.search_providers import Belga360ArchiveSearchProvider
+from belga.search_providers import Belga360ArchiveSearchProvider, get_datetime
 
 
 def fixture(filename):
@@ -76,6 +76,8 @@ class Belga360ArchiveTestCase(unittest.TestCase):
         self.assertEqual(item['creditline'], 'BELGA')
         self.assertEqual(item['source'], 'BELGA')
         self.assertEqual(item['language'], 'fr')
+        self.assertEqual(item['firstcreated'], get_datetime(1581646440))
+        self.assertEqual(item['versioncreated'], get_datetime(1581654480))
         self.assertEqual(item['abstract'], (
             'Vivamus rutrum sapien a purus posuere eleifend. Integer non feugiat sapien. Proin'
             ' finibus diam in urna vehicula accumsan'

--- a/server/tests/belga_360_archive_test.py
+++ b/server/tests/belga_360_archive_test.py
@@ -1,14 +1,12 @@
 import os
-import unittest
 import superdesk
 
 import arrow
 from flask import json
 from httmock import all_requests, HTTMock
 from unittest.mock import MagicMock
-from superdesk.factory import get_app as get_sd_app
-
 from belga.search_providers import Belga360ArchiveSearchProvider, get_datetime
+from superdesk.tests import TestCase
 
 
 def fixture(filename):
@@ -34,7 +32,7 @@ def get_belga360_item():
         return items['newsObjects'][0]
 
 
-class Belga360ArchiveTestCase(unittest.TestCase):
+class Belga360ArchiveTestCase(TestCase):
     def setUp(self):
         self.provider = Belga360ArchiveSearchProvider(dict())
         self.query = {
@@ -121,8 +119,7 @@ class Belga360ArchiveTestCase(unittest.TestCase):
 
     def test_get_periods(self):
         arrow.now = MagicMock(return_value=arrow.get('2020-02-14'))
-        with get_sd_app().app_context():
-            day_period = self.provider._get_period('day')
+        day_period = self.provider._get_period('day')
         self.assertEqual(day_period['fromDate'], '20200213')
         self.assertEqual(day_period['toDate'], '20200214')
 

--- a/server/tests/fixtures/belga-360archive-search.json
+++ b/server/tests/fixtures/belga-360archive-search.json
@@ -9,6 +9,8 @@
             "headLine": "Lorem ipsum dolor sit amet, consectetur adipiscing elit.",
             "language": "fr",
             "source": "BELGA",
+            "createDate": 1581646440000,
+            "validateDate": 1581654480000,
             "newsComponents": [
                 {
                     "newsComponentId": 0,


### PR DESCRIPTION
1. Display date for Archive search item (SDBELGA-271)
  Map `firstcreated` and `versioncreated` (used in [listItems](https://github.com/superdesk/superdesk-client-core/blob/develop/scripts/apps/search/components/ListItemInfo.tsx#L56) > [firstLine](https://github.com/superdesk/superdesk-client-core/blob/develop/scripts/apps/search/constants.ts#L52))
  Should we also map `firstpublished` field for using in [Belga NewsML export](https://github.com/superdesk/superdesk-belga/blob/master/server/belga/publish/belga_newsml_1_2.py#L333)?
2. Add advanced search, search parameters are provided in **SDBELGA-173**:
- Search by headline is removed, based on @karelpetrak 's feedback, user should use full text search
- Search by **period** will override search by **date**
- For 24h period, because belga APIs only provide search by date, so we will display result for both _today and yesterday_

SDBELGA-271
SDBELGA-288