### PR TITLE
[SDBELGA-376] Fix unable add belga archive as related

### DIFF
--- a/server/belga/search_providers.py
+++ b/server/belga/search_providers.py
@@ -277,7 +277,7 @@ class Belga360ArchiveSearchProvider(superdesk.SearchProvider):
         created = get_datetime(datetime.datetime.now())
         return {
             'type': 'text',
-            'mimetype': 'application/superdesk.vnd.belga.360archive',
+            'mimetype': 'application/superdesk.item.text',
             'pubstatus': 'usable',
             '_id': guid,
             'state': 'published',

--- a/server/tests/belga_360_archive_test.py
+++ b/server/tests/belga_360_archive_test.py
@@ -64,7 +64,7 @@ class Belga360ArchiveTestCase(unittest.TestCase):
         item = self.provider.format_list_item(get_belga360_item())
         guid = 'urn:belga.be:360archive:39670442'
         self.assertEqual(item['type'], 'text')
-        self.assertEqual(item['mimetype'], 'application/superdesk.vnd.belga.360archive')
+        self.assertEqual(item['mimetype'], 'application/superdesk.item.text')
         self.assertEqual(item['_id'], guid)
         self.assertEqual(item['state'], 'published')
         self.assertEqual(item['guid'], guid)


### PR DESCRIPTION
This is the same as https://github.com/superdesk/superdesk-belga/pull/177
If we understand correctly, based on [this line](https://github.com/superdesk/superdesk-client-core/blob/develop/scripts/apps/relations/directives/RelatedItemsDirective.ts#L93), any item does not have type `superdesk.item.text`/picture/video, could not add as related item because [event is removed](https://github.com/superdesk/superdesk-client-core/blob/develop/scripts/apps/relations/directives/RelatedItemsDirective.ts#L102), but for some odd reason, Firefox still trigger event while Chrome does not, we have looked into it but still not sure what's problem with Firefox?!

@ride90 Is there anyway to custom [`ALLOWED_TYPE`](https://github.com/superdesk/superdesk-client-core/blob/develop/scripts/apps/relations/directives/RelatedItemsDirective.ts#L91)? We think `mimetype` is not important for now, but just in case we need it in the future.
This is a small change so we create another PR instead of merging it into https://github.com/superdesk/superdesk-belga/pull/200 for easier review.

Tested in Chrome 80 and Firefox 75 on Linux 5.6.3

SDBELGA-376