### PR TITLE
[SDBELGA-410] Add profile for belga archive items

### DIFF
--- a/server/belga/search_providers.py
+++ b/server/belga/search_providers.py
@@ -235,8 +235,7 @@ class Belga360ArchiveSearchProvider(superdesk.SearchProvider):
         super().__init__(provider)
         self.session = requests.Session()
         self.content_types = {
-            c['_id']: c['_id']
-            for c in superdesk.get_resource_service('content_types').find({})
+            c['_id'] for c in superdesk.get_resource_service('content_types').find({})
         }
 
     def url(self, resource):
@@ -322,8 +321,10 @@ class Belga360ArchiveSearchProvider(superdesk.SearchProvider):
     def _get_profile(self, profile):
         label = profile.lower()
         if label == 'short':
-            return self.content_types.get('text')
-        return self.content_types.get(label)
+            label = 'text'
+        if label not in self.content_types:
+            return
+        return label
 
     def format_list_item(self, data):
         guid = '%s%d' % (self.GUID_PREFIX, data['newsObjectId'])

--- a/server/belga/search_providers.py
+++ b/server/belga/search_providers.py
@@ -1,7 +1,6 @@
 import hmac
 import uuid
 import arrow
-import json
 import hashlib
 import requests
 import superdesk

--- a/server/belga/search_providers.py
+++ b/server/belga/search_providers.py
@@ -235,8 +235,10 @@ class Belga360ArchiveSearchProvider(superdesk.SearchProvider):
     def __init__(self, provider):
         super().__init__(provider)
         self.session = requests.Session()
-        with open('data/content_types.json') as f:
-            self.content_types = {c['label'].lower(): c['_id'] for c in json.load(f)}
+        self.content_types = {
+            c['label'].lower(): c['_id']
+            for c in superdesk.get_resource_service('content_types').find({})
+        }
 
     def url(self, resource):
         return urljoin(self.base_url, resource.lstrip('/'))

--- a/server/belga/search_providers.py
+++ b/server/belga/search_providers.py
@@ -235,7 +235,7 @@ class Belga360ArchiveSearchProvider(superdesk.SearchProvider):
         super().__init__(provider)
         self.session = requests.Session()
         self.content_types = {
-            c['label'].lower(): c['_id']
+            c['_id']: c['_id']
             for c in superdesk.get_resource_service('content_types').find({})
         }
 

--- a/server/tests/search_providers/belga_360_archive_test.py
+++ b/server/tests/search_providers/belga_360_archive_test.py
@@ -76,6 +76,7 @@ class Belga360ArchiveTestCase(TestCase):
         self.assertEqual(item['mimetype'], 'application/superdesk.item.text')
         self.assertEqual(item['_id'], guid)
         self.assertEqual(item['state'], 'published')
+        self.assertEqual(item['profile'], 'text')
         self.assertEqual(item['guid'], guid)
         self.assertEqual(item['extra']['bcoverage'], guid)
         self.assertEqual(item['headline'], 'Lorem ipsum dolor sit amet, consectetur adipiscing elit.')

--- a/server/tests/search_providers/belga_360_archive_test.py
+++ b/server/tests/search_providers/belga_360_archive_test.py
@@ -70,6 +70,12 @@ class Belga360ArchiveTestCase(TestCase):
         self.provider.session.get.assert_called_with(url, params=params)
 
     def test_format_list_item(self):
+        self.app.data.insert(
+            'content_types',
+            [{'_id': 'text', 'label': 'text'}]
+        )
+        # reload content profiles
+        self.provider = Belga360ArchiveSearchProvider(dict())
         item = self.provider.format_list_item(get_belga360_item())
         guid = 'urn:belga.be:360archive:39670442'
         self.assertEqual(item['type'], 'text')


### PR DESCRIPTION
Display profile for Belga Archive items
- Use profile in `content_profiles.json` instead of `content_profiles` service as we have discussed
- If profile is `Short`, use `Text`, and leave it empty if it does not exist in superdesk

SDBELGA-410