### PR TITLE
Sort out content profiles naming in staging and production

### DIFF
--- a/server/belga/macros/brief_internal_routing.py
+++ b/server/belga/macros/brief_internal_routing.py
@@ -1,9 +1,8 @@
 
 import logging
 import superdesk
-from typing import List, Dict
+from typing import List
 
-from flask import current_app as app
 from datetime import timedelta
 from superdesk.metadata.item import CONTENT_STATE, PUBLISH_SCHEDULE, SCHEDULE_SETTINGS
 from superdesk.macros.internal_destination_auto_publish import internal_destination_auto_publish
@@ -27,7 +26,7 @@ PRODUCT_MAPPING = {
 }
 
 TEXT_PROFILE = 'TEXT'
-BRIEF_PROFILE = 'Brief'
+BRIEF_PROFILE = 'BRIEF'
 
 logger = logging.getLogger(__name__)
 

--- a/server/data_updates/00007_20201228-144144_content_types.py
+++ b/server/data_updates/00007_20201228-144144_content_types.py
@@ -1,0 +1,124 @@
+# -*- coding: utf-8; -*-
+# This file is part of Superdesk.
+# For the full copyright and license information, please see the
+# AUTHORS and LICENSE files distributed with this source code, or
+# at https://www.sourcefabric.org/superdesk/license
+#
+# Author  : olegpshenichniy
+# Creation: 2020-12-28 14:41
+
+from copy import copy
+
+from flask import current_app
+
+from superdesk.commands.data_updates import DataUpdate
+
+
+class DataUpdate(DataUpdate):
+
+    resource = 'content_types'
+
+    def __init__(self):
+        super().__init__()
+
+        self._resource_content_types = current_app.data.get_mongo_collection(self.resource)
+        self._resource_content_templates = current_app.data.get_mongo_collection('content_templates')
+        self._resource_desks = current_app.data.get_mongo_collection('desks')
+        self._resource_archive = current_app.data.get_mongo_collection('archive')
+        self._resource_published = current_app.data.get_mongo_collection('published')
+        self._resource_archive_autosave = current_app.data.get_mongo_collection('archive_autosave')
+        self._resource_archive_versions = current_app.data.get_mongo_collection('archive_versions')
+        self._map_content_types_ids = {
+            # replaceable_id: replacement_id
+        }
+
+    def forwards(self, mongodb_collection, mongodb_database):
+        # fill content types mapping
+        cursor = self._resource_content_types.find(
+            {
+                'label': {
+                    '$in': ('ALERT custom', 'BRIEF custom', 'TEXT custom', 'TIP custom')
+                }
+            },
+            {'_id': 1, 'label': 1}
+        )
+        for item in cursor:
+            old_id = item['_id']
+            new_id = item['label'].split(' custom')[0].lower()
+            self._map_content_types_ids[old_id] = new_id
+
+        # replace old `data.profile` id with new one in content templates
+        for old_id, new_id in self._map_content_types_ids.items():
+            print(f'Replace "{old_id}" with "{new_id}" in "content_templates.data.profile"')
+            result = self._resource_content_templates.update_many(
+                {'data.profile': str(old_id)},
+                {'$set': {'data.profile': new_id}}
+            )
+            print('matched={} updated={}'.format(result.matched_count, result.modified_count))
+
+        # replace old `default_content_profile` id with new one in desks
+        for old_id, new_id in self._map_content_types_ids.items():
+            print(f'Replace "{old_id}" with "{new_id}" in "desks.default_content_profile"')
+            result = self._resource_desks.update_many(
+                {'default_content_profile': str(old_id)},
+                {'$set': {'default_content_profile': new_id}}
+            )
+            print('matched={} updated={}'.format(result.matched_count, result.modified_count))
+
+        # replace old `profile` id with new one in archive
+        for old_id, new_id in self._map_content_types_ids.items():
+            print(f'Replace "{old_id}" with "{new_id}" in "archive.profile"')
+            result = self._resource_archive.update_many(
+                {
+                    '$or': [
+                        {'profile': str(old_id)},
+                        {'profile': old_id}
+                    ]
+                },
+                {'$set': {'profile': new_id}}
+            )
+            print('matched={} updated={}'.format(result.matched_count, result.modified_count))
+
+        # replace old `profile` id with new one in (archive/published/archive_autosave).associations.*.profile
+
+        # add the same ids but without ObjectID
+        map_content_types_ids = copy(self._map_content_types_ids)
+        map_content_types_ids.update({str(k): v for k, v in map_content_types_ids.items()})
+
+        for resource, resource_name in ((self._resource_archive, 'archive'),
+                                        (self._resource_published, 'published'),
+                                        (self._resource_archive_versions, 'archive_versions'),
+                                        (self._resource_archive_autosave, 'archive_autosave')):
+            for item in resource.find({'associations': {'$exists': True}}):
+                hitdb = False
+
+                if not item['associations']:
+                    continue
+
+                for k, v in item['associations'].items():
+                    if v and v.get('profile') in map_content_types_ids.keys():
+                        old_id = v['profile']
+                        new_id = map_content_types_ids[v['profile']]
+                        item['associations'][k]['profile'] = map_content_types_ids[v['profile']]
+                        hitdb = True
+                        print(f'Item: {item["_id"]}. Replace "{old_id}" with "{new_id}" '
+                              f'in "{resource_name}.associations.{k}.profile"')
+                if not hitdb:
+                    continue
+                resource.update_one(
+                    {'_id': item['_id']},
+                    {'$set': {'associations': item['associations']}}
+                )
+
+        # remove old content types
+        print(f'Remove "{self._map_content_types_ids.keys()}" from "content_types"')
+        _filter = {
+            '_id': {
+                '$in': tuple(self._map_content_types_ids.keys())
+            }
+        }
+        result = self._resource_content_types.delete_many(_filter)
+        print(f'deleted={{{result.deleted_count}}}')
+
+    def backwards(self, mongodb_collection, mongodb_database):
+        raise NotImplementedError()

--- a/server/tests/macros/brief_internal_routing_macro_test.py
+++ b/server/tests/macros/brief_internal_routing_macro_test.py
@@ -59,7 +59,7 @@ class BriefInternalRoutingMacroTestCase(tests.TestCase):
 
     def setUp(self):
         self.profiles = self.app.data.insert('content_types', [
-            {'label': 'Brief'},
+            {'label': 'BRIEF'},
             {'label': 'TEXT'},
         ])
         self.now = utcnow()


### PR DESCRIPTION
SDBELGA-436

We store fixed content profiles in the json file and these profiles were imported during init data cmnd.
On Belga stage/prod instance content profiles were also created manually (which is wrong), so at the end, it was a conflict between imported (correct) profiles and manually created. 
This PR does next steps:
- replace **manually created** `data.profile` id with **the content profile from json** in `content_templates`
- replace **manually created** `default_content_profile` id with **the content profile from json** in `desks`
- replace **manually created** `profile` id with **the content profile from json** in `archive`
- replace **manually created** `profile` id with **the content profile from json** in `archive.associations.*.profile`
- replace **manually created** `profile` id with **the content profile from json** in `published.associations.*.profile`
- replace **manually created** `profile` id with **the content profile from json** in `archive_autosave.associations.*.profile`
- replace **manually created** `profile` id with **the content profile from json** in `archive_versions.associations.*.profile`
- remove manually created content types

P.S. I've tested it with DB dump from the stage instance.