### PR TITLE
[FEED PARSER][BELGA NEWSML 1.2] Don't overwritte `guid` with `Duid` a…

### DIFF
--- a/server/belga/io/feed_parsers/base_belga_newsml_1_2.py
+++ b/server/belga/io/feed_parsers/base_belga_newsml_1_2.py
@@ -239,7 +239,7 @@ class BaseBelgaNewsMLOneFeedParser(BelgaNewsMLMixin, NewsMLOneFeedParser):
 
             element = newsident_el.find('NewsItemId')
             if element is not None:
-                item['item_id'] = element.text
+                item["guid"] = item["item_id"] = element.text
 
             element = newsident_el.find('RevisionId')
             if element is not None:
@@ -355,7 +355,7 @@ class BaseBelgaNewsMLOneFeedParser(BelgaNewsMLMixin, NewsMLOneFeedParser):
         if component_el is None:
             return
 
-        if component_el.attrib.get('Duid') is not None:
+        if component_el.attrib.get('Duid') is not None and "guid" not in item:
             item['guid'] = component_el.attrib.get('Duid', '')
 
         # Essential is CV

--- a/server/tests/io/feed_parsers/belga_efe_newsml_1_2_test.py
+++ b/server/tests/io/feed_parsers/belga_efe_newsml_1_2_test.py
@@ -55,7 +55,7 @@ class BelgaEFENewsMLOneTestCase(TestCase):
         self.assertEqual(item["date_id"], "20190121T103600+0000")
         self.assertEqual(item["item_id"], "25413502")
         self.assertEqual(item["version"], "1")
-        self.assertEqual(item["guid"], "text_25413502.text")
+        self.assertEqual(item["guid"], "urn:newsml:texto.efeservicios.com:20190121T103600+0000:25413502:1")
         self.assertEqual(str(item["firstcreated"]), "2019-01-21 10:36:00+00:00")
         self.assertEqual(str(item["versioncreated"]), "2019-01-21 10:36:00+00:00")
         self.assertEqual(item["pubstatus"], "usable")

--- a/server/tests/io/feed_parsers/belga_kyodo_newsml_1_2_test.py
+++ b/server/tests/io/feed_parsers/belga_kyodo_newsml_1_2_test.py
@@ -26,7 +26,7 @@ class BelgaKyodoNewsMLTestCase(TestCase):
         self.assertEqual(item["keywords"], [])
         self.assertEqual(item['date_id'], '20190723')
         self.assertEqual(item['format'], 'Nitf_v3.0')
-        self.assertEqual(item['guid'], 'NC0001')
+        self.assertEqual(item['guid'], 'urn:newsml:kyodonews.jp:20190723:20161021KW___0003800010:1')
         self.assertEqual(item['item_id'], '20161021KW___0003800010')
         self.assertEqual(item['priority'], 9)
         self.assertEqual(item['provider_id'], 'kyodonews.jp')


### PR DESCRIPTION
…ttribute

`guid` is set from `PublicIdentifier` when available, or `NewsItemId`.
If none is available, `NewsComponent`'s `Duid` attribute is used.

SDBELGA-467