### PR TITLE
FIX: ANP keywords ingest issue when keywords are empty in files

### DIFF
--- a/server/belga/io/feed_parsers/belga_newsml_mixin.py
+++ b/server/belga/io/feed_parsers/belga_newsml_mixin.py
@@ -27,6 +27,9 @@ class BelgaNewsMLMixin:
         ]
 
     def _get_countries(self, country_code):
+        if not country_code:
+            return []
+
         countries = get_resource_service('vocabularies').get_items(
             _id='countries',
             qcode=country_code.lower()
@@ -35,6 +38,9 @@ class BelgaNewsMLMixin:
         return countries
 
     def _get_keywords(self, data):
+        if not data:
+            return []
+
         _belga_keyword_list = get_resource_service('vocabularies').get_items(
             _id='belga-keywords',
             qcode=data.upper()


### PR DESCRIPTION
when we have empty keywords in XML file then after ingesting it is showing all the Belga-keywords in UI, related to https://github.com/superdesk/superdesk-belga/pull/347#issue-1000684799 SDBELGA-521