### PR TITLE
FIX: Resolve belga-keywords, country and country keywords issue in belga specific ANP, AFP, DPA, EFE, Itartass parsers

### DIFF
--- a/server/belga/io/feed_parsers/base_belga_newsml_1_2.py
+++ b/server/belga/io/feed_parsers/base_belga_newsml_1_2.py
@@ -92,7 +92,7 @@ class BaseBelgaNewsMLOneFeedParser(BelgaNewsMLMixin, NewsMLOneFeedParser):
                     item['keywords'] = []
                     # remove duplicated subject
                     item['subject'] = [
-                        dict(i) for i, _ in itertools.groupby(sorted(item['subject'], key=lambda k: k['name']))
+                        dict(i) for i, _ in itertools.groupby(sorted(item['subject'], key=lambda k: k['qcode']))
                     ]
                     item = self.populate_fields(item)
                 except SkipItemException:

--- a/server/belga/io/feed_parsers/belga_dpa_newsml_2_0.py
+++ b/server/belga/io/feed_parsers/belga_dpa_newsml_2_0.py
@@ -123,7 +123,7 @@ class BelgaDPANewsMLTwoFeedParser(BelgaNewsMLMixin, NewsMLTwoFeedParser):
 
                     # remove duplicated subject
                     item['subject'] = [
-                        dict(i) for i, _ in itertools.groupby(sorted(item['subject'], key=lambda k: k['name']))
+                        dict(i) for i, _ in itertools.groupby(sorted(item['subject'], key=lambda k: k['qcode']))
                     ]
                     items.append(item)
             return items

--- a/server/belga/io/feed_parsers/belga_newsml_mixin.py
+++ b/server/belga/io/feed_parsers/belga_newsml_mixin.py
@@ -45,7 +45,7 @@ class BelgaNewsMLMixin:
         if belga_keyword:
             return belga_keyword
 
-        countries = self._get_mapped_keywords(data.lower(), data.capitalize(), "countries")
+        countries = self._get_mapped_keywords(data.lower(), data.title(), "countries")
         if countries:
             return countries + self._get_country(countries[0]["qcode"])
 

--- a/server/tests/io/feed_parsers/belga_afp_newsml_1_2_test.py
+++ b/server/tests/io/feed_parsers/belga_afp_newsml_1_2_test.py
@@ -46,7 +46,6 @@ class BelgaAFPNewsMLOneTestCase(TestCase):
                 'name': {'nl': 'FRANKRIJK', 'fr': 'FRANCE'}}, 'scheme': 'country'},
             {'name': 'France', 'qcode': 'fra', 'translations': {
                 'name': {'nl': 'Frankrijk', 'fr': 'France'}}, 'scheme': 'countries'},
-            {'name': 'France', 'qcode': 'France', 'scheme': 'original-metadata'},
             {'name': 'MOA-TFG-1=MOA', 'qcode': 'MOA-TFG-1=MOA', 'scheme': 'of_interest_to'},
             {'name': 'NEWS/ECONOMY', 'qcode': 'NEWS/ECONOMY', 'parent': 'NEWS', 'scheme': 'services-products'},
             {'name': 'NEWS/GENERAL', 'qcode': 'NEWS/GENERAL', 'parent': 'NEWS', 'scheme': 'services-products'},

--- a/server/tests/io/feed_parsers/belga_kyodo_newsml_1_2_test.py
+++ b/server/tests/io/feed_parsers/belga_kyodo_newsml_1_2_test.py
@@ -34,12 +34,12 @@ class BelgaKyodoNewsMLTestCase(TestCase):
         self.assertEqual(item['firstcreated'].isoformat(), '2019-07-23T20:21:19+09:00')
         self.assertEqual(item['versioncreated'].isoformat(), '2019-07-23T20:21:19+09:00')
         self.assertEqual(item['subject'], [
+            {'name': 'NEWS/GENERAL', 'parent': 'NEWS', 'qcode': 'NEWS/GENERAL', 'scheme': 'services-products'},
             {'name': 'France', 'qcode': 'country_fra', 'scheme': 'country',
              'translations': {'name': {'fr': 'FRANCE', 'nl': 'FRANKRIJK'}}},
+            {'name': 'default', 'qcode': 'default', 'scheme': 'distribution'},
             {'name': 'France', 'qcode': 'fra', 'translations': {
              'name': {'nl': 'Frankrijk', 'fr': 'France'}}, 'scheme': 'countries'},
-            {'name': 'NEWS/GENERAL', 'parent': 'NEWS', 'qcode': 'NEWS/GENERAL', 'scheme': 'services-products'},
-            {'name': 'default', 'qcode': 'default', 'scheme': 'distribution'},
             {'name': 'no', 'qcode': 'no', 'scheme': 'essential'},
             {'name': 'no', 'qcode': 'no', 'scheme': 'equivalents_list'},
         ])


### PR DESCRIPTION
related to [SDBELGA-566] and [SDBELGA-521]

[SDBELGA-566]: https://sofab.atlassian.net/browse/SDBELGA-566?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[SDBELGA-521]: https://sofab.atlassian.net/browse/SDBELGA-521?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ