### PR TITLE
Belga archive API: Provide first published timestamp for items of type related [SDBELGA-631]

### DIFF
--- a/server/belga/search_providers.py
+++ b/server/belga/search_providers.py
@@ -514,7 +514,7 @@ class Belga360ArchiveSearchProvider(superdesk.SearchProvider, BelgaNewsMLMixin):
             # SDBELGA-665
             "ednote": get_text(data.get("editorialInfo")),
         }
-        if data.get("assetType") == "RelatedArticle":
+        if data.get("assetType") == "RelatedArticle" and data.get("comments") != "":
             formatted_data["firstpublished"] = datetime.strptime(
                 data.get("comments"), "%Y%m%d%H%M%S"
             ).replace(tzinfo=utc)

--- a/server/belga/search_providers.py
+++ b/server/belga/search_providers.py
@@ -514,7 +514,7 @@ class Belga360ArchiveSearchProvider(superdesk.SearchProvider, BelgaNewsMLMixin):
             # SDBELGA-665
             "ednote": get_text(data.get("editorialInfo")),
         }
-        if data.get("assetType") == "RelatedArticle" and data.get("comments") != "":
+        if data.get("assetType") == "RelatedArticle" and data.get("comments"):
             formatted_data["firstpublished"] = datetime.strptime(
                 data.get("comments"), "%Y%m%d%H%M%S"
             ).replace(tzinfo=utc)


### PR DESCRIPTION
In some cases we got `data["comment] =  "" `, so here we handle it.