### PR TITLE
Fix: Advisory templates have missing lines breaks and time formatting [SDBELGA-796]

### DIFF
--- a/server/belga/planning_exports/common.py
+++ b/server/belga/planning_exports/common.py
@@ -40,7 +40,7 @@ def set_item_dates(item: Dict[str, Any], event: Dict[str, Any]):
     start_local_str = start_local.strftime("%Hu%M")
 
     item["local_time"] = start_local_str
-    item["local_date_str"] = start_local.strftime("%Y-%m-%d")
+    item["local_date_time"] = start_local
 
 
 def set_item_location(item: Dict[str, Any], event: Dict[str, Any]):
@@ -78,9 +78,9 @@ def get_subject(event: Dict[str, Any], language: str):
 
 
 def format_datetime(event: Dict[str, Any], locale: str, format: str):
-    return format_date(
-        event.get("dates", {}).get("start"), format, locale=locale
-    ).capitalize()
+    tz = event.get("dates", {}).get("tz") or app.config.get("DEFAULT_TIMEZONE")
+    start_time = event.get("dates", {}).get("start")
+    return format_date(utc_to_local(tz, start_time), format, locale=locale).capitalize()
 
 
 def set_metadata(formatted_event: Dict[str, Any], event: Dict[str, Any]):

--- a/server/belga/planning_exports/dutch_news_events_list.py
+++ b/server/belga/planning_exports/dutch_news_events_list.py
@@ -14,8 +14,8 @@ def format_event_dutch(event_data: List[Dict[str, Any]]):
         }
         set_metadata(formatted_event, event)
 
-        if formatted_event["local_date_str"] != current_date:
-            current_date = formatted_event["local_date_str"]
+        if formatted_event["local_date_time"] != current_date:
+            current_date = formatted_event["local_date_time"]
             formatted_current_date = format_datetime(event, "nl", "EEEE d MMMM")
             events_list.append({"date": formatted_current_date, "events": []})
         events_list[-1]["events"].append(formatted_event)

--- a/server/belga/planning_exports/france_news_event_list.py
+++ b/server/belga/planning_exports/france_news_event_list.py
@@ -13,8 +13,8 @@ def format_event_french(event_data: List[Dict[str, Any]]):
             "subject": ",".join(get_subject(event, "fr")),
         }
         set_metadata(formatted_event, event)
-        if formatted_event["local_date_str"] != current_date:
-            current_date = formatted_event["local_date_str"]
+        if formatted_event["local_date_time"] != current_date:
+            current_date = formatted_event["local_date_time"]
             formatted_current_date = format_datetime(event, "fr", "EEEE d MMMM")
             events_list.append({"date": formatted_current_date, "events": []})
         events_list[-1]["events"].append(formatted_event)

--- a/server/templates/dutch_news_events_list_export.html
+++ b/server/templates/dutch_news_events_list_export.html
@@ -8,13 +8,12 @@
 <div>
     {% for event in day_events.events %}
     <div>
-        <p>{{ event.subject }}</p>
-        <p>{{ event.address.name }}, {{event.address.country}}</p>
-        <p>{{ event.local_time }}</p>
-        <p>{{ event.title }}</p>
-        <p>{{ event.description }}</p>
+        <p>{{ event.subject }}<br></p>
+        <p>{{ event.address.name }}, {{event.address.country}}<br></p>
+        <p>{{ event.local_time }}, {{ event.title }}<br></p>
+        <p>{{ event.description }}<br></p>
         {% for link in event.links %}
-        <p><a href="{{ link }}">{{ link }}</a></p>
+        <p><a href="{{ link }}">{{ link }}</a><br></p>
         {% endfor %}
     </div>
     {% endfor %}

--- a/server/templates/french_news_events_list_export.html
+++ b/server/templates/french_news_events_list_export.html
@@ -8,13 +8,12 @@
 <div>
     {% for event in day_events.events %}
     <div>
-        <p>{{ event.subject }}</p>
-        <p>{{ event.address.name }}, {{event.address.country}}</p>
-        <p>{{ event.local_time }}</p>
-        <p>{{ event.title }}</p>
-        <p>{{ event.description }}</p>
+        <p>{{ event.subject }}<br></p>
+        <p>{{ event.address.name }}, {{event.address.country}}<br></p>
+        <p>{{ event.local_time }}, {{ event.title }}<br></p>
+        <p>{{ event.description }}<br></p>
         {% for link in event.links %}
-        <p><a href="{{ link }}">{{ link }}</a></p>
+        <p><a href="{{ link }}">{{ link }}</a><br></p>
         {% endfor %}
     </div>
     {% endfor %}

--- a/server/tests/planning_export/planning_export_tests.py
+++ b/server/tests/planning_export/planning_export_tests.py
@@ -113,22 +113,24 @@ class PlanningExportTests(TestCase):
                 dutch_template_data,
             )
             self.assertIn("<h3>Zondag 21 april</h3>", dutch_template_data)
-            self.assertIn("<p>REDWOLVES</p>", dutch_template_data)
-            self.assertIn("<p>New York, United States</p>", dutch_template_data)
-            self.assertIn("<p>16u00</p>", dutch_template_data)
-            self.assertIn("<p>NExxxxt Sunday 21.04.2024</p>", dutch_template_data)
-            self.assertIn("<p>Description of event</p>", dutch_template_data)
+            self.assertIn("<p>REDWOLVES<br></p>", dutch_template_data)
+            self.assertIn("<p>New York, United States<br></p>", dutch_template_data)
             self.assertIn(
-                '<p><a href="www.google.xom/new">www.google.xom/new</a></p>',
+                "<p>16u00, NExxxxt Sunday 21.04.2024<br></p>", dutch_template_data
+            )
+            self.assertIn("<p>Description of event<br></p>", dutch_template_data)
+            self.assertIn(
+                '<p><a href="www.google.xom/new">www.google.xom/new</a><br></p>',
                 dutch_template_data,
             )
             self.assertIn("<h3>Maandag 22 april</h3>", dutch_template_data)
-            self.assertIn("<p>SPORTS</p>", dutch_template_data)
-            self.assertIn("<p>16u00</p>", dutch_template_data)
-            self.assertIn("<p>NExxxxt Monday 22.04.2024</p>", dutch_template_data)
-            self.assertIn("<p>Description of event</p>", dutch_template_data)
+            self.assertIn("<p>SPORTS<br></p>", dutch_template_data)
             self.assertIn(
-                '<p><a href="www.google.xom/new">www.google.xom/new</a></p>',
+                "<p>16u00, NExxxxt Monday 22.04.2024<br></p>", dutch_template_data
+            )
+            self.assertIn("<p>Description of event<br></p>", dutch_template_data)
+            self.assertIn(
+                '<p><a href="www.google.xom/new">www.google.xom/new</a><br></p>',
                 dutch_template_data,
             )
 
@@ -147,21 +149,45 @@ class PlanningExportTests(TestCase):
                 french_template_data,
             )
             self.assertIn("<h3>Dimanche 21 avril</h3>", french_template_data)
-            self.assertIn("<p>REDWOLVES</p>", french_template_data)
-            self.assertIn("<p>New York, United States</p>", french_template_data)
-            self.assertIn("<p>16u00</p>", french_template_data)
-            self.assertIn("<p>NExxxxt Sunday 21.04.2024</p>", french_template_data)
-            self.assertIn("<p>Description of event</p>", french_template_data)
+            self.assertIn("<p>REDWOLVES<br></p>", french_template_data)
+            self.assertIn("<p>New York, United States<br></p>", french_template_data)
             self.assertIn(
-                '<p><a href="www.google.xom/new">www.google.xom/new</a></p>',
+                "<p>16u00, NExxxxt Sunday 21.04.2024<br></p>", french_template_data
+            )
+            self.assertIn("<p>Description of event<br></p>", french_template_data)
+            self.assertIn(
+                '<p><a href="www.google.xom/new">www.google.xom/new</a><br></p>',
                 french_template_data,
             )
             self.assertIn("<h3>Lundi 22 avril</h3>", french_template_data)
-            self.assertIn("<p>SPORTS</p>", french_template_data)
-            self.assertIn("<p>16u00</p>", french_template_data)
-            self.assertIn("<p>NExxxxt Monday 22.04.2024</p>", french_template_data)
-            self.assertIn("<p>Description of event</p>", french_template_data)
+            self.assertIn("<p>SPORTS<br></p>", french_template_data)
             self.assertIn(
-                '<p><a href="www.google.xom/new">www.google.xom/new</a></p>',
+                "<p>16u00, NExxxxt Monday 22.04.2024<br></p>", french_template_data
+            )
+            self.assertIn("<p>Description of event<br></p>", french_template_data)
+            self.assertIn(
+                '<p><a href="www.google.xom/new">www.google.xom/new</a><br></p>',
                 french_template_data,
             )
+
+            new_events = [
+                {
+                    "dates": {
+                        "start": datetime.datetime(
+                            2024, 4, 24, 22, 00, 00, tzinfo=datetime.timezone.utc
+                        ),
+                        "end": datetime.datetime(
+                            2024, 4, 25, 21, 59, 59, tzinfo=datetime.timezone.utc
+                        ),
+                        "tz": "Europe/Prague",
+                    }
+                }
+            ]
+            template_data = render_template(
+                "dutch_news_events_list_export.html", items=new_events, app=app
+            )
+            self.assertIn("<h3>Donderdag 25 april</h3>", template_data)
+            template_data = render_template(
+                "french_news_events_list_export.html", items=new_events, app=app
+            )
+            self.assertIn("<h3>Jeudi 25 avril</h3>", template_data)


### PR DESCRIPTION
some events are listed under wrong date because we don't convert time to local : [comment](https://sofab.atlassian.net/browse/SDBELGA-784?focusedCommentId=129355)

[SDBELGA-784](https://sofab.atlassian.net/browse/SDBELGA-784)

[SDBELGA-784]: https://sofab.atlassian.net/browse/SDBELGA-784?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ