### PR TITLE
Fix advisory templates editor formatting issues

### DIFF
--- a/server/templates/dutch_news_events_list_export_body.html
+++ b/server/templates/dutch_news_events_list_export_body.html
@@ -1,23 +1,18 @@
 {% set formatted_data = format_event_for_week(items, "nl") %}
-<div>
-    <p>De belangrijkste sportevenementen op de Belgische en internationale sportkalender van {{ formatted_data.start_date }} tot {{ formatted_data.end_date }} {{ formatted_data.month }}:</p>
-</div>
+<p>De belangrijkste sportevenementen op de Belgische en internationale sportkalender van {{ formatted_data.start_date }} tot {{ formatted_data.end_date }} {{ formatted_data.month }}:</p>
+
 {% for day_events in formatted_data.events_list %}
     <h3>{{ day_events.date.capitalize()}}</h3>
-    <div>
-        {% for subject, events in day_events.subjects.items() | sort %}
-            <h4>{{ subject }}</h4>
-            {% for event in events %}
-            <div>
-                <p>{{ event.local_time }}, {{ event.title }}<br></p>
-                {% if event.location %}<p>{{ event.location }}<br></p>{% endif %}
-                {% if event.description %}<p>{{ event.description }}<br></p>{% endif %}
-                {% for link in event.links %}
-                    <p><a href="{{ link }}">{{ link }}</a><br></p>
-                {% endfor %}
-            </div>
-            {% endfor %}
-            <div><br></div>
+
+    {% for subject, events in day_events.subjects.items() | sort %}
+        <h4>{{ subject }}</h4>
+        {% for event in events %}
+        <p>{{ event.local_time }}, {{ event.title }}</p>
+        {% if event.location %}<p>{{ event.location }}</p>{% endif %}
+        {% if event.description %}<p>{{ event.description }}</p>{% endif %}
+        {% for link in event.links %}
+            <p><a href="{{ link }}">{{ link }}</a></p>
         {% endfor %}
-    </div>
+        {% endfor %}
+    {% endfor %}
 {% endfor %}

--- a/server/templates/dutch_news_events_tommorrow.html
+++ b/server/templates/dutch_news_events_tommorrow.html
@@ -1,36 +1,29 @@
 {% set formatted_data = format_event_for_tommorow(items, "nl") %}
-
-<div>
-    <h2>Dit is de Belga-agenda van de Belgische en internationale gebeurtenissen, met de vermelding of wij dit in TEXT, PICTURE, VIDEO, AUDIO, INFOGRAPHICS, LIVE VIDEO en LIVE BLOG coveren. De vermelding ON MERIT betekent dat Belga dit onderwerp opvolgt, maar dat voorlopig niet gegarandeerd kan worden dat er ook een specifieke coverage zal volgen. De redactie van Belga wenst u een prettige werkdag.</h2>
-</div>
+<h2>Dit is de Belga-agenda van de Belgische en internationale gebeurtenissen, met de vermelding of wij dit in TEXT, PICTURE, VIDEO, AUDIO, INFOGRAPHICS, LIVE VIDEO en LIVE BLOG coveren. De vermelding ON MERIT betekent dat Belga dit onderwerp opvolgt, maar dat voorlopig niet gegarandeerd kan worden dat er ook een specifieke coverage zal volgen. De redactie van Belga wenst u een prettige werkdag.</h2>
 
 {% for data in formatted_data %}
     <h3>{{ data.calendar }}</h3>
-    <div>
-        {% for event in data.events %}
-            <div>
-                <p>{{ event.time }}<br></p>
-                
-                {% if event.location %}
-                    <p>{{ event.location }}<br></p>
-                {% endif %}
-                
-                {% if event.title %}<p>{{ event.title }}<br></p>{% endif %}
-                {% if event.description %}<p>{{ event.description }}<br></p>{% endif %}
-                
-                {% for link in event.links %}
-                    <p><a href='{{ link }}'>{{ link }}</a><br></p>
-                {% endfor %}
-                
-                {% for contact in event.contacts %}
-                <p>{{ contact.organisation }} - {{ contact.name }} - {{ contact.job_title }} - {{ contact.email|join(", ") }} - {{ contact.phone|join(", ") }} - {{ contact.mobile|join(", ") }} - {{ contact.website }}<br></p>
-                {% endfor %}
-                
-                {% for coverage in event.coverages %}
-                    <p>{{ coverage }}<br></p>
-                {% endfor %}
-                <br>
-            </div>
+
+    {% for event in data.events %}
+        <p>{{ event.time }}</p>
+
+        {% if event.location %}
+            <p>{{ event.location }}</p>
+        {% endif %}
+
+        {% if event.title %}<p>{{ event.title }}</p>{% endif %}
+        {% if event.description %}<p>{{ event.description }}</p>{% endif %}
+
+        {% for link in event.links %}
+            <p><a href='{{ link }}'>{{ link }}</a></p>
         {% endfor %}
-    </div>
+
+        {% for contact in event.contacts %}
+        <p>{{ contact.organisation }} - {{ contact.name }} - {{ contact.job_title }} - {{ contact.email|join(", ") }} - {{ contact.phone|join(", ") }} - {{ contact.mobile|join(", ") }} - {{ contact.website }}</p>
+        {% endfor %}
+
+        {% for coverage in event.coverages %}
+            <p>{{ coverage }}</p>
+        {% endfor %}
+    {% endfor %}
 {% endfor %}

--- a/server/templates/dutch_planning_advisory_tomorrow.html
+++ b/server/templates/dutch_planning_advisory_tomorrow.html
@@ -1,30 +1,24 @@
 {% set formatted_data = format_planning_for_tomorrow(items, 'nl') %}
-
-<div>
-    <h2>Dit is de Belga-agenda van de Belgische en internationale gebeurtenissen, met de vermelding of wij dit in TEXT, PICTURE, VIDEO, AUDIO, INFOGRAPHICS, LIVE VIDEO en LIVE BLOG coveren. De vermelding ON MERIT betekent dat Belga dit onderwerp opvolgt, maar dat voorlopig niet gegarandeerd kan worden dat er ook een specifieke coverage zal volgen. De redactie van Belga wenst u een prettige werkdag.</h2>
-</div>
+<h2>Dit is de Belga-agenda van de Belgische en internationale gebeurtenissen, met de vermelding of wij dit in TEXT, PICTURE, VIDEO, AUDIO, INFOGRAPHICS, LIVE VIDEO en LIVE BLOG coveren. De vermelding ON MERIT betekent dat Belga dit onderwerp opvolgt, maar dat voorlopig niet gegarandeerd kan worden dat er ook een specifieke coverage zal volgen. De redactie van Belga wenst u een prettige werkdag.</h2>
 
 {% for data in formatted_data %}
     <h3>{{ data.calendar }}</h3>
-    <div>
-        {% for event in data.events %}
-            <div>
-                <p>{{ event.time }}</p>
-                {% if event.location %}
-                    <p>{{ event.location }}</p>
-                {% endif %}
-                <p>{{ event.title }}</p>
-                <p>{{ event.description }}</p>
-                {% for link in event.links %}
-                    <p><a href='{{ link }}'>{{ link }}</a></p>
-                {% endfor %}
-                {% for contact in event.contacts %}
-                    <p>{{ contact.organisation }} - {{ contact.name }} - {{ contact.job_title }} - {{ contact.email|join(", ") }} - {{ contact.phone|join(", ") }} - {{ contact.mobile|join(", ") }} - {{ contact.website }}</p>
-                {% endfor %}
-                {% for coverage in event.coverages %}
-                    <p>{{ coverage }}</p>
-                {% endfor %}
-            </div>
+
+    {% for event in data.events %}
+        <p>{{ event.time }}</p>
+        {% if event.location %}
+            <p>{{ event.location }}</p>
+        {% endif %}
+        <p>{{ event.title }}</p>
+        <p>{{ event.description }}</p>
+        {% for link in event.links %}
+            <p><a href='{{ link }}'>{{ link }}</a></p>
         {% endfor %}
-    </div>
+        {% for contact in event.contacts %}
+            <p>{{ contact.organisation }} - {{ contact.name }} - {{ contact.job_title }} - {{ contact.email|join(", ") }} - {{ contact.phone|join(", ") }} - {{ contact.mobile|join(", ") }} - {{ contact.website }}</p>
+        {% endfor %}
+        {% for coverage in event.coverages %}
+            <p>{{ coverage }}</p>
+        {% endfor %}
+    {% endfor %}
 {% endfor %}

--- a/server/templates/french_news_events_list_export_body.html
+++ b/server/templates/french_news_events_list_export_body.html
@@ -1,23 +1,18 @@
 {% set formatted_data = format_event_for_week(items, "fr") %}
-<div>
-    <p>Principaux événements inscrits au calendrier sportif international du {{ formatted_data.start_date }} au {{ formatted_data.end_date }} {{ formatted_data.month }} :</p>
-</div>
+<p>Principaux événements inscrits au calendrier sportif international du {{ formatted_data.start_date }} au {{ formatted_data.end_date }} {{ formatted_data.month }} :</p>
+
 {% for day_events in formatted_data.events_list %}
     <h3>{{ day_events.date.capitalize() }}</h3>
-    <div>
-        {% for subject, events in day_events.subjects.items() | sort %}
-            <h4>{{ subject }}</h4>
-            {% for event in events %}
-            <div>
-                <p>{{ event.local_time }}, {{ event.title }}<br></p>
-                {% if event.location %}<p>{{ event.location }}<br></p>{% endif %}
-                {% if event.description %}<p>{{ event.description }}<br></p>{% endif %}
-                {% for link in event.links %}
-                    <p><a href="{{ link }}">{{ link }}</a><br></p>
-                {% endfor %}
-            </div>
+
+    {% for subject, events in day_events.subjects.items() | sort %}
+        <h4>{{ subject }}</h4>
+        {% for event in events %}
+            <p>{{ event.local_time }}, {{ event.title }}</p>
+            {% if event.location %}<p>{{ event.location }}</p>{% endif %}
+            {% if event.description %}<p>{{ event.description }}</p>{% endif %}
+            {% for link in event.links %}
+                <p><a href="{{ link }}">{{ link }}</a></p>
             {% endfor %}
-            <div><br></div>
         {% endfor %}
-    </div>
+    {% endfor %}
 {% endfor %}

--- a/server/templates/french_news_events_tommorrow.html
+++ b/server/templates/french_news_events_tommorrow.html
@@ -1,36 +1,29 @@
 {% set formatted_data = format_event_for_tommorow(items, "fr") %}
-
-<div>
-    <h2>Voici l’agenda Belga des événements belges et internationaux qui bénéficieront d’une couverture de notre part. Les mentions TEXT, PICTURE, VIDEO, AUDIO, INFOGRAPHICS, LIVE VIDEO et LIVE BLOG vous précisent si nous couvrons le sujet. La mention ON MERIT vous signale que Belga suit le sujet mais ne peut pas encore assurer qu’il donnera lieu à une couverture spécifique. La rédaction vous souhaite une bonne journée de travail</h2>
-</div>
+<h2>Voici l’agenda Belga des événements belges et internationaux qui bénéficieront d’une couverture de notre part. Les mentions TEXT, PICTURE, VIDEO, AUDIO, INFOGRAPHICS, LIVE VIDEO et LIVE BLOG vous précisent si nous couvrons le sujet. La mention ON MERIT vous signale que Belga suit le sujet mais ne peut pas encore assurer qu’il donnera lieu à une couverture spécifique. La rédaction vous souhaite une bonne journée de travail</h2>
 
 {% for data in formatted_data %}
     <h3>{{ data.calendar }}</h3>
-    <div>
-        {% for event in data.events %}
-            <div>
-                <p>{{ event.time }}<br></p>
-                
-                {% if event.location %}
-                    <p>{{ event.location }}<br></p>
-                {% endif %}
-                
-                {% if event.title %}<p>{{ event.title }}<br></p>{% endif %}
-                {% if event.description %}<p>{{ event.description }}<br></p>{% endif %}
-                
-                {% for link in event.links %}
-                    <p><a href='{{ link }}'>{{ link }}</a><br></p>
-                {% endfor %}
-                
-                {% for contact in event.contacts %}
-                <p>{{ contact.organisation }} - {{ contact.name }} - {{ contact.job_title }} - {{ contact.email|join(", ") }} - {{ contact.phone|join(", ") }} - {{ contact.mobile|join(", ") }} - {{ contact.website }}<br></p>
-                {% endfor %}
-                
-                {% for coverage in event.coverages %}
-                    <p>{{ coverage }}<br></p>
-                {% endfor %}
-                <br>
-            </div>
-        {% endfor %}
-    </div>
+
+    {% for event in data.events %}
+    <p>{{ event.time }}</p>
+
+    {% if event.location %}
+        <p>{{ event.location }}</p>
+    {% endif %}
+
+    {% if event.title %}<p>{{ event.title }}</p>{% endif %}
+    {% if event.description %}<p>{{ event.description }}</p>{% endif %}
+
+    {% for link in event.links %}
+        <p><a href='{{ link }}'>{{ link }}</a></p>
+    {% endfor %}
+
+    {% for contact in event.contacts %}
+    <p>{{ contact.organisation }} - {{ contact.name }} - {{ contact.job_title }} - {{ contact.email|join(", ") }} - {{ contact.phone|join(", ") }} - {{ contact.mobile|join(", ") }} - {{ contact.website }}</p>
+    {% endfor %}
+
+    {% for coverage in event.coverages %}
+        <p>{{ coverage }}</p>
+    {% endfor %}
+    {% endfor %}
 {% endfor %}

--- a/server/templates/french_planning_advisory_tomorrow.html
+++ b/server/templates/french_planning_advisory_tomorrow.html
@@ -1,30 +1,24 @@
 {% set formatted_data = format_planning_for_tomorrow(items, 'fr') %}
-
-<div>
-    <h2>Voici l’agenda Belga des événements belges et internationaux qui bénéficieront d’une couverture de notre part. Les mentions TEXT, PICTURE, VIDEO, AUDIO, INFOGRAPHICS, LIVE VIDEO et LIVE BLOG vous précisent si nous couvrons le sujet. La mention ON MERIT vous signale que Belga suit le sujet mais ne peut pas encore assurer qu’il donnera lieu à une couverture spécifique. La rédaction vous souhaite une bonne journée de travail</h2>
-</div>
+<h2>Voici l’agenda Belga des événements belges et internationaux qui bénéficieront d’une couverture de notre part. Les mentions TEXT, PICTURE, VIDEO, AUDIO, INFOGRAPHICS, LIVE VIDEO et LIVE BLOG vous précisent si nous couvrons le sujet. La mention ON MERIT vous signale que Belga suit le sujet mais ne peut pas encore assurer qu’il donnera lieu à une couverture spécifique. La rédaction vous souhaite une bonne journée de travail</h2>
 
 {% for data in formatted_data %}
     <h3>{{ data.calendar }}</h3>
-    <div>
-        {% for event in data.events %}
-            <div>
-                <p>{{ event.time }}</p>
-                {% if event.location %}
-                    <p>{{ event.location }}</p>
-                {% endif %}
-                <p>{{ event.title }}</p>
-                <p>{{ event.description }}</p>
-                {% for link in event.links %}
-                    <p><a href='{{ link }}'>{{ link }}</a></p>
-                {% endfor %}
-                {% for contact in event.contacts %}
-                    <p>{{ contact.organisation }} - {{ contact.name }} - {{ contact.job_title }} - {{ contact.email|join(", ") }} - {{ contact.phone|join(", ") }} - {{ contact.mobile|join(", ") }} - {{ contact.website }}</p>
-                {% endfor %}
-                {% for coverage in event.coverages %}
-                    <p>{{ coverage }}</p>
-                {% endfor %}
-            </div>
+
+    {% for event in data.events %}
+        <p>{{ event.time }}</p>
+        {% if event.location %}
+            <p>{{ event.location }}</p>
+        {% endif %}
+        <p>{{ event.title }}</p>
+        <p>{{ event.description }}</p>
+        {% for link in event.links %}
+            <p><a href='{{ link }}'>{{ link }}</a></p>
         {% endfor %}
-    </div>
+        {% for contact in event.contacts %}
+            <p>{{ contact.organisation }} - {{ contact.name }} - {{ contact.job_title }} - {{ contact.email|join(", ") }} - {{ contact.phone|join(", ") }} - {{ contact.mobile|join(", ") }} - {{ contact.website }}</p>
+        {% endfor %}
+        {% for coverage in event.coverages %}
+            <p>{{ coverage }}</p>
+        {% endfor %}
+    {% endfor %}
 {% endfor %}


### PR DESCRIPTION
SDBELGA-972

**Purpose:**
The current templates had unsupported tags like `div`. They were also not following the expected format of the editor - `br` tags are not needed for a new line because after each paragraph the editor adds spacing internally and treats it as content a new line. We have specific `p` and `br` tag handling [here](https://github.com/superdesk/superdesk-client-core/blob/eef343677b37577c35d870fd32f32e77528a7ee9/scripts/core/editor3/html/to-html/editor3StateToHtml.ts#L90) which strips `br` tags causing the formatting changes after saving and reopening. 

**What has changed:**
Removed redundant `div` and `br` tags. 