### PR TITLE
Daily program in two languages for the Event and Planning advisories [SDBELGA-979]

### DIFF
--- a/server/belga/planning_exports/__init__.py
+++ b/server/belga/planning_exports/__init__.py
@@ -4,6 +4,9 @@ from .format_planning_for_tomorrow import format_planning_for_tomorrow
 from .format_planning_for_tomorrow_bilingual import (
     format_planning_for_tomorrow_bilingual,
 )
+from .format_news_events_tommorow_bilingual import (
+    format_event_for_tommorow_bilingual,
+)
 
 
 def init_app(app):
@@ -14,4 +17,7 @@ def init_app(app):
     )
     app.jinja_env.globals.update(
         format_planning_for_tomorrow_bilingual=format_planning_for_tomorrow_bilingual
+    )
+    app.jinja_env.globals.update(
+        format_event_for_tommorow_bilingual=format_event_for_tommorow_bilingual
     )

--- a/server/belga/planning_exports/format_news_events_tommorow_bilingual.py
+++ b/server/belga/planning_exports/format_news_events_tommorow_bilingual.py
@@ -117,6 +117,7 @@ def get_coverages_bilingual(event: Dict[str, Any]) -> List[Dict[str, Any]]:
     formatted_coverages = []
     planning_ids = event.get("planning_ids", [])
     planning_service = get_resource_service("planning")
+    desk_service = get_resource_service("desks")
 
     for planning_id in planning_ids:
         planning_item = planning_service.find_one(req=None, _id=planning_id)
@@ -130,24 +131,43 @@ def get_coverages_bilingual(event: Dict[str, Any]) -> List[Dict[str, Any]]:
             planning_info = coverage.get("planning", {})
             cov_type = (planning_info.get("g2_content_type") or "").lower()
             cov_status = (
-                coverage.get("news_coverage_status", {}).get("label", "ON MERIT")
-            ).upper()
-            cov_language = planning_info.get("language", "nl")
+                coverage.get("news_coverage_status", {})
+                .get("label", "ON MERIT")
+                .upper()
+            )
 
-            # Format coverage for bilingual output
-            if cov_type == "text":
-                # Text coverages get language-specific tags (TEXT N / TEXT F)
-                coverage_display = f"TEXT {cov_language.upper()[0]} ({cov_status})"
-            else:
-                # Other coverage types don't get language tags
-                coverage_display = f"{cov_type.upper()} ({cov_status})"
+            desk_language_code = "N"
+            desk_id = (
+                planning_info.get("desk")
+                or coverage.get("assigned_to", {}).get("desk")
+                or event.get("task", {}).get("desk")
+            )
+
+            if desk_id:
+                desk_item = desk_service.find_one(req=None, _id=desk_id)
+                if desk_item:
+                    lang = desk_item.get("desk_language")
+                    if lang:
+                        lang = lang.lower()
+                        if lang in ("nl", "n", "de"):
+                            desk_language_code = "N"
+                        elif lang in ("fr", "f"):
+                            desk_language_code = "F"
+                        else:
+                            desk_language_code = "N"
+
+            coverage_display = (
+                f"TEXT {desk_language_code} ({cov_status})"
+                if cov_type == "text"
+                else f"{cov_type.upper()} ({cov_status})"
+            )
 
             formatted_coverages.append(
                 {
                     "display": coverage_display,
                     "type": cov_type,
                     "status": cov_status,
-                    "language": cov_language,
+                    "language": desk_language_code,
                 }
             )
 

--- a/server/belga/planning_exports/format_news_events_tommorow_bilingual.py
+++ b/server/belga/planning_exports/format_news_events_tommorow_bilingual.py
@@ -1,0 +1,154 @@
+from .common import (
+    set_metadata,
+    get_subjects,
+    get_formatted_contacts,
+    get_item_location,
+    set_event_translations_value,
+)
+from typing import List, Dict, Any
+from superdesk.utc import utc_to_local
+from superdesk import get_resource_service
+
+CALENDAR_ORDER = [
+    "General",
+    "Politics",
+    "Economy",
+    "Regional",
+    "Justice",
+    "International",
+    "Sports",
+    "Culture",
+]
+
+
+def format_event_for_tommorow_bilingual(
+    event_data: List[Dict[str, Any]], locale: str
+) -> List[Dict[str, Any]]:
+    """Format events into bilingual event list for advisory output"""
+    events_list: List[Dict[str, Any]] = []
+    calendar_groups: Dict[str, List[Dict[str, Any]]] = {}
+
+    # Process events for both languages
+    for event in event_data:
+        # Get Dutch version
+        event_nl = event.copy()
+        set_event_translations_value(event_nl, "nl")
+
+        # Get French version
+        event_fr = event.copy()
+        set_event_translations_value(event_fr, "fr")
+
+        calendar = (
+            event["calendars"][0]["qcode"].capitalize()
+            if event.get("calendars")
+            else "Overig / Divers"
+        )
+
+        formatted_event = {
+            "subject": ",".join(get_subjects(event, "nl")),
+            "calendar": calendar,
+            "contacts": get_formatted_contacts(event),
+            "coverages": get_coverages_bilingual(event),
+            "location": get_item_location(event, "nl"),
+            "title_nl": event_nl.get("name") or event_nl.get("slugline") or "",
+            "title_fr": event_fr.get("name") or event_fr.get("slugline") or "",
+            "description_nl": (
+                event_nl.get("definition_long")
+                or event_nl.get("description_text")
+                or event_nl.get("definition_short")
+                or ""
+            ).rstrip(),
+            "description_fr": (
+                event_fr.get("definition_long")
+                or event_fr.get("description_text")
+                or event_fr.get("definition_short")
+                or ""
+            ).rstrip(),
+        }
+
+        # Set metadata (links, etc.)
+        set_metadata(formatted_event, event, locale)
+
+        # Set dates and handle all-day events
+        dates = event["dates"]
+        tz = dates.get("tz") or "Europe/Brussels"
+        start_local = utc_to_local(tz, dates["start"])
+        end_local = utc_to_local(tz, dates["end"])
+
+        # Check if this is an all-day event (00:00-23:59)
+        is_all_day = (
+            start_local.hour == 0
+            and start_local.minute == 0
+            and end_local.hour == 23
+            and end_local.minute == 59
+        )
+
+        if is_all_day:
+            # For all-day events, don't show the time range
+            formatted_event["time"] = ""
+        else:
+            # Show specific time range
+            formatted_event["time"] = (
+                f"{start_local.strftime('%H:%M')} - {end_local.strftime('%H:%M')}"
+            )
+
+        calendar_groups.setdefault(calendar, []).append(formatted_event)
+
+    # Sort and merge by CALENDAR_ORDER
+    for calendar in CALENDAR_ORDER + sorted(
+        [c for c in calendar_groups if c not in CALENDAR_ORDER]
+    ):
+        if calendar in calendar_groups:
+            # Sort events: timed events first, then all-day events
+            events_sorted = sorted(
+                calendar_groups[calendar],
+                key=lambda x: (
+                    x["time"] == "",
+                    x["time"],
+                ),  # Empty time (all-day) goes last
+            )
+            events_list.append({"calendar": calendar, "events": events_sorted})
+
+    return events_list
+
+
+def get_coverages_bilingual(event: Dict[str, Any]) -> List[Dict[str, Any]]:
+    """Get coverages with language information formatted for bilingual output"""
+    formatted_coverages = []
+    planning_ids = event.get("planning_ids", [])
+    planning_service = get_resource_service("planning")
+
+    for planning_id in planning_ids:
+        planning_item = planning_service.find_one(req=None, _id=planning_id)
+        if not planning_item:
+            continue
+
+        for coverage in planning_item.get("coverages", []):
+            if not isinstance(coverage, dict):
+                continue
+
+            planning_info = coverage.get("planning", {})
+            cov_type = (planning_info.get("g2_content_type") or "").lower()
+            cov_status = (
+                coverage.get("news_coverage_status", {}).get("label", "ON MERIT")
+            ).upper()
+            cov_language = planning_info.get("language", "nl")
+
+            # Format coverage for bilingual output
+            if cov_type == "text":
+                # Text coverages get language-specific tags (TEXT N / TEXT F)
+                coverage_display = f"TEXT {cov_language.upper()[0]} ({cov_status})"
+            else:
+                # Other coverage types don't get language tags
+                coverage_display = f"{cov_type.upper()} ({cov_status})"
+
+            formatted_coverages.append(
+                {
+                    "display": coverage_display,
+                    "type": cov_type,
+                    "status": cov_status,
+                    "language": cov_language,
+                }
+            )
+
+    return formatted_coverages

--- a/server/belga/planning_exports/format_planning_for_tomorrow_bilingual.py
+++ b/server/belga/planning_exports/format_planning_for_tomorrow_bilingual.py
@@ -133,6 +133,7 @@ def get_coverages_bilingual(event: Dict[str, Any]) -> List[Dict[str, Any]]:
     formatted_coverages = []
     planning_ids = event.get("planning_ids", [])
     planning_service = get_resource_service("planning")
+    desk_service = get_resource_service("desks")
 
     for planning_id in planning_ids:
         planning_item = planning_service.find_one(req=None, _id=planning_id)
@@ -148,14 +149,24 @@ def get_coverages_bilingual(event: Dict[str, Any]) -> List[Dict[str, Any]]:
             cov_status = (
                 coverage.get("news_coverage_status", {}).get("label", "ON MERIT")
             ).upper()
-            cov_language = planning_info.get("language", "nl")
 
-            # Format coverage for bilingual output
+            desk_language_code = "N"
+            desk_id = (
+                planning_info.get("desk")
+                or coverage.get("assigned_to", {}).get("desk")
+                or event.get("task", {}).get("desk")
+            )
+
+            if desk_id:
+                desk_item = desk_service.find_one(req=None, _id=desk_id)
+                if desk_item:
+                    lang = desk_item.get("desk_language")
+                    if lang:
+                        desk_language_code = "N" if lang.lower() in ("nl", "n") else "F"
+
             if cov_type == "text":
-                # Text coverages get language-specific tags (TEXT N / TEXT F)
-                coverage_display = f"TEXT {cov_language.upper()[0]} ({cov_status})"
+                coverage_display = f"TEXT {desk_language_code} ({cov_status})"
             else:
-                # Other coverage types don't get language tags
                 coverage_display = f"{cov_type.upper()} ({cov_status})"
 
             formatted_coverages.append(
@@ -163,7 +174,7 @@ def get_coverages_bilingual(event: Dict[str, Any]) -> List[Dict[str, Any]]:
                     "display": coverage_display,
                     "type": cov_type,
                     "status": cov_status,
-                    "language": cov_language,
+                    "language": desk_language_code,
                 }
             )
 

--- a/server/belga/planning_exports/format_planning_for_tomorrow_bilingual.py
+++ b/server/belga/planning_exports/format_planning_for_tomorrow_bilingual.py
@@ -29,7 +29,10 @@ def format_planning_for_tomorrow_bilingual(
 
     # Collect unique event IDs from planning items with matching coverages
     event_ids = set()
+    standalone_plannings: List[Dict[str, Any]] = []
+
     for item in planning_data:
+        has_valid_coverage = False
         for coverage in item.get("coverages", []):
             cov_type = None
 
@@ -39,8 +42,14 @@ def format_planning_for_tomorrow_bilingual(
             elif isinstance(coverage, str):
                 cov_type = coverage.lower()
 
-            if cov_type in ["picture", "video", "text"] and item.get("event_item"):
-                event_ids.add(item["event_item"])
+            if cov_type in ["picture", "video", "text"]:
+                has_valid_coverage = True
+                if item.get("event_item"):
+                    event_ids.add(item["event_item"])
+
+        # If coverage exists but no linked event → keep as standalone planning
+        if has_valid_coverage and not item.get("event_item"):
+            standalone_plannings.append(item)
 
     # Fetch associated events
     events_service = get_resource_service("events")
@@ -53,23 +62,20 @@ def format_planning_for_tomorrow_bilingual(
 
     # Process events for both languages
     for event in events:
-        # Get Dutch version
-        event_nl = event.copy()
-        set_event_translations_value(event_nl, "nl")
-
-        # Get French version
-        event_fr = event.copy()
-        set_event_translations_value(event_fr, "fr")
-
         calendar = (
             event["calendars"][0]["qcode"].capitalize()
             if event.get("calendars")
             else "Overig / Divers"
         )
 
+        event_nl = event.copy()
+        set_event_translations_value(event_nl, "nl")
+        event_fr = event.copy()
+        set_event_translations_value(event_fr, "fr")
+
         formatted_event = {
             "subject": ",".join(get_subjects(event, "nl")),
-            "calendars": calendar,
+            "calendar": calendar,
             "contacts": get_formatted_contacts(event),
             "coverages": get_coverages_bilingual(event),
             "location": get_item_location(event, "nl"),
@@ -104,16 +110,31 @@ def format_planning_for_tomorrow_bilingual(
             and end_local.minute == 59
         )
 
-        if is_all_day:
-            # For all-day events, don't show the time range
-            formatted_event["time"] = ""
-        else:
-            # Show specific time range
-            formatted_event["time"] = (
-                f"{start_local.strftime('%H:%M')} - {end_local.strftime('%H:%M')}"
-            )
+        formatted_event["time"] = (
+            ""
+            if is_all_day
+            else (f"{start_local.strftime('%H:%M')} - {end_local.strftime('%H:%M')}")
+        )
 
         calendar_groups.setdefault(calendar, []).append(formatted_event)
+
+    for planning in standalone_plannings:
+        calendar = "Overig / Divers"
+
+        formatted_planning = {
+            "subject": "",
+            "calendar": calendar,
+            "coverages": get_coverages_bilingual(planning),
+            "location": get_item_location(planning, "nl"),
+            "links": planning.get("links", []),
+            "title_nl": planning.get("slugline") or planning.get("headline") or "",
+            "title_fr": planning.get("slugline") or planning.get("headline") or "",
+            "description_nl": (planning.get("description_text") or "").rstrip(),
+            "description_fr": (planning.get("description_text") or "").rstrip(),
+            "time": "",
+        }
+
+        calendar_groups.setdefault(calendar, []).append(formatted_planning)
 
     # Sort and merge by CALENDAR_ORDER
     for calendar in CALENDAR_ORDER + sorted(
@@ -128,12 +149,15 @@ def format_planning_for_tomorrow_bilingual(
     return events_list
 
 
-def get_coverages_bilingual(event: Dict[str, Any]) -> List[Dict[str, Any]]:
-    """Get coverages with language information formatted for bilingual output"""
+def get_coverages_bilingual(item: Dict[str, Any]) -> List[Dict[str, Any]]:
+    """Get coverage info with language and status for bilingual output"""
     formatted_coverages = []
-    planning_ids = event.get("planning_ids", [])
     planning_service = get_resource_service("planning")
     desk_service = get_resource_service("desks")
+
+    lang_map = {"nl": "N", "n": "N", "fr": "F", "f": "F", "de": "N"}
+
+    planning_ids = item.get("planning_ids") or [item.get("_id")]
 
     for planning_id in planning_ids:
         planning_item = planning_service.find_one(req=None, _id=planning_id)
@@ -144,26 +168,32 @@ def get_coverages_bilingual(event: Dict[str, Any]) -> List[Dict[str, Any]]:
             if not isinstance(coverage, dict):
                 continue
 
-            planning_info = coverage.get("planning", {})
-            cov_type = (planning_info.get("g2_content_type") or "").lower()
+            # Coverage type
+            planning_info = coverage.get("planning") or {}
+            cov_type = (
+                planning_info.get("g2_content_type")
+                or coverage.get("g2_content_type")
+                or ""
+            ).lower()
             cov_status = (
-                coverage.get("news_coverage_status", {}).get("label", "ON MERIT")
+                coverage.get("news_coverage_status", {}).get("label") or "ON MERIT"
             ).upper()
 
+            # Desk language
             desk_language_code = "N"
             desk_id = (
                 planning_info.get("desk")
                 or coverage.get("assigned_to", {}).get("desk")
-                or event.get("task", {}).get("desk")
+                or item.get("task", {}).get("desk")
             )
 
             if desk_id:
                 desk_item = desk_service.find_one(req=None, _id=desk_id)
                 if desk_item:
-                    lang = desk_item.get("desk_language")
-                    if lang:
-                        desk_language_code = "N" if lang.lower() in ("nl", "n") else "F"
+                    lang = desk_item.get("desk_language", "").lower()
+                    desk_language_code = lang_map.get(lang, "N")
 
+            # Format coverage display
             if cov_type == "text":
                 coverage_display = f"TEXT {desk_language_code} ({cov_status})"
             else:

--- a/server/data/planning_export_templates.json
+++ b/server/data/planning_export_templates.json
@@ -91,5 +91,15 @@
       "body_html_template": "bilingual_planning_advisory_tomorrow.html"
   },
   "label": "Daily program (NL/FR)"
+},
+{
+  "_id": "bilingual_events_advisory_tomorrow", 
+  "init_version": 1,
+  "name": "bilingual_events_advisory_tomorrow",
+  "type": "event",
+  "data": {
+    "body_html_template": "bilingual_news_events_tommorrow.html"
+  },
+  "label": "Daily program Events (NL/FR)"
 }
 ]

--- a/server/templates/bilingual_news_events_tommorrow.html
+++ b/server/templates/bilingual_news_events_tommorrow.html
@@ -1,0 +1,48 @@
+{% set formatted_data = format_event_for_tommorow_bilingual(items, "bilingual") %}
+<h2>Dit is de Belga-agenda van de Belgische en internationale gebeurtenissen, met de vermelding of wij dit in TEXT, PICTURE, VIDEO, AUDIO, INFOGRAPHICS, LIVE VIDEO en LIVE BLOG coveren. De vermelding ON MERIT betekent dat Belga dit onderwerp opvolgt, maar dat voorlopig niet gegarandeerd kan worden dat er ook een specifieke coverage zal volgen. De redactie van Belga wenst u een prettige werkdag.</h2>
+
+<h2>Voici l'agenda Belga des événements belges et internationaux qui bénéficieront d'une couverture de notre part. Les mentions TEXT, PICTURE, VIDEO, AUDIO, INFOGRAPHICS, LIVE VIDEO et LIVE BLOG vous précisent si nous couvrons le sujet. La mention ON MERIT vous signale que Belga suit le sujet mais ne peut pas encore assurer qu'il donnera lieu à une couverture spécifique. La rédaction vous souhaite une bonne journée de travail</h2>
+
+{% for data in formatted_data %}
+    <h3>{{ data.calendar }}</h3>
+
+    {% for event in data.events %}
+        {% if event.time %}<p>{{ event.time }}</p>{% endif %}
+
+        {% if event.location %}
+            <p>{{ event.location }}</p>
+        {% endif %}
+
+        {# Display both Dutch and French titles if they differ #}
+        {% if event.title_nl and event.title_fr and event.title_nl != event.title_fr %}
+            <p>{{ event.title_nl }}</p>
+            <p>{{ event.title_fr }}</p>
+        {% elif event.title_nl %}
+            <p>{{ event.title_nl }}</p>
+        {% elif event.title_fr %}
+            <p>{{ event.title_fr }}</p>
+        {% endif %}
+
+        {# Display both Dutch and French descriptions if they differ #}
+        {% if event.description_nl and event.description_fr and event.description_nl != event.description_fr %}
+            <p>{{ event.description_nl }}</p>
+            <p>{{ event.description_fr }}</p>
+        {% elif event.description_nl %}
+            <p>{{ event.description_nl }}</p>
+        {% elif event.description_fr %}
+            <p>{{ event.description_fr }}</p>
+        {% endif %}
+
+        {% for link in event.links %}
+            <p><a href="{{ link }}">{{ link }}</a></p>
+        {% endfor %}
+
+        {% for contact in event.contacts %}
+            <p>{{ contact.organisation }} - {{ contact.name }} - {{ contact.job_title }} - {{ contact.email|join(", ") }} - {{ contact.phone|join(", ") }} - {{ contact.mobile|join(", ") }} - {{ contact.website }}</p>
+        {% endfor %}
+
+        {% for coverage in event.coverages %}
+            <p>{{ coverage.display }}</p>
+        {% endfor %}
+    {% endfor %}
+{% endfor %}

--- a/server/tests/planning_export/planning_export_tests.py
+++ b/server/tests/planning_export/planning_export_tests.py
@@ -1139,3 +1139,359 @@ class PlanningExportTests(TestCase):
             self.assertNotIn(
                 "00:00 - 23:59", politics_section, "All-day event should not show time"
             )
+
+    def test_bilingual_events_advisory_export_tomorrow(self):
+        """Test the bilingual events advisory template with various scenarios"""
+        with self.app.app_context():
+            test_contact_id = ObjectId()
+            test_contact = {
+                "_id": test_contact_id,
+                "first_name": "John",
+                "last_name": "Doe",
+                "organisation": "Test Org",
+                "job_title": "Media Contact",
+                "contact_email": ["jdoe@test.org"],
+                "contact_phone": [{"number": "123456789", "public": True}],
+                "mobile": [{"number": "987654321", "public": True}],
+                "website": "test.org",
+            }
+            self.app.data.insert("contacts", [test_contact])
+
+            event_1_id = ObjectId()
+            event_2_id = ObjectId()
+            event_3_id = ObjectId()
+
+            bilingual_events = [
+                {
+                    "_id": event_1_id,
+                    "name": "Test Event NL",
+                    "slugline": "test-event-nl",
+                    "definition_long": "Dutch description of the event",
+                    "dates": {
+                        "start": datetime.datetime(
+                            2024, 4, 22, 9, 0, 0, tzinfo=datetime.timezone.utc
+                        ),
+                        "end": datetime.datetime(
+                            2024, 4, 22, 17, 0, 0, tzinfo=datetime.timezone.utc
+                        ),
+                        "tz": "Europe/Brussels",
+                    },
+                    "calendars": [{"qcode": "general", "name": "General"}],
+                    "location": [
+                        {
+                            "name": "Brussels",
+                            "address": {"city": "Brussels", "country": "Belgium"},
+                        }
+                    ],
+                    "links": ["http://test-event.com"],
+                    "event_contact_info": [str(test_contact_id)],
+                    "translations": [
+                        {"field": "name", "language": "fr", "value": "Test Event FR"},
+                        {
+                            "field": "definition_long",
+                            "language": "fr",
+                            "value": "French description of the event",
+                        },
+                    ],
+                },
+                {
+                    "_id": event_2_id,
+                    "name": "All Day Event NL",
+                    "slugline": "all-day-event",
+                    "definition_long": "This is an all-day event in Dutch",
+                    "dates": {
+                        "start": datetime.datetime(
+                            2024, 4, 22, 0, 0, 0, tzinfo=datetime.timezone.utc
+                        ),
+                        "end": datetime.datetime(
+                            2024, 4, 22, 23, 59, 59, tzinfo=datetime.timezone.utc
+                        ),
+                        "tz": "Europe/Brussels",
+                    },
+                    "calendars": [{"qcode": "politics", "name": "Politics"}],
+                    "location": [
+                        {
+                            "name": "Brussels",
+                            "address": {"city": "Brussels", "country": "Belgium"},
+                        }
+                    ],
+                    "links": ["http://allday-event.com"],
+                    "event_contact_info": [str(test_contact_id)],
+                    "translations": [
+                        {
+                            "field": "name",
+                            "language": "fr",
+                            "value": "All Day Event FR",
+                        },
+                        {
+                            "field": "definition_long",
+                            "language": "fr",
+                            "value": "This is an all-day event in French",
+                        },
+                    ],
+                },
+                {
+                    "_id": event_3_id,
+                    "name": "Single Language Event",
+                    "slugline": "single-language",
+                    "definition_long": "Event with only one language",
+                    "dates": {
+                        "start": datetime.datetime(
+                            2024, 4, 22, 14, 0, 0, tzinfo=datetime.timezone.utc
+                        ),
+                        "end": datetime.datetime(
+                            2024, 4, 22, 16, 0, 0, tzinfo=datetime.timezone.utc
+                        ),
+                        "tz": "Europe/Brussels",
+                    },
+                    "calendars": [{"qcode": "economy", "name": "Economy"}],
+                    "location": [
+                        {
+                            "name": "Antwerp",
+                            "address": {"city": "Antwerp", "country": "Belgium"},
+                        }
+                    ],
+                    "links": ["http://single-event.com"],
+                    "event_contact_info": [str(test_contact_id)],
+                    # No translations - should fall back to default language
+                },
+            ]
+
+            self.app.data.insert("events", bilingual_events)
+
+            planning_1_id = ObjectId()
+            planning_2_id = ObjectId()
+            planning_3_id = ObjectId()
+            planning_4_id = ObjectId()
+            planning_5_id = ObjectId()
+
+            planning_items = [
+                {
+                    "_id": planning_1_id,
+                    "type": "planning",
+                    "slugline": "planning-dutch-text",
+                    "description_text": "Planning for Dutch text coverage",
+                    "dates": bilingual_events[0]["dates"],
+                    "coverages": [
+                        {
+                            "coverage_id": "cov1",
+                            "planning": {"g2_content_type": "text", "language": "nl"},
+                            "news_coverage_status": {"label": "Planned"},
+                        }
+                    ],
+                    "event_item": event_1_id,
+                },
+                {
+                    "_id": planning_2_id,
+                    "type": "planning",
+                    "slugline": "planning-french-text",
+                    "description_text": "Planning for French text coverage",
+                    "dates": bilingual_events[0]["dates"],
+                    "coverages": [
+                        {
+                            "coverage_id": "cov2",
+                            "planning": {"g2_content_type": "text", "language": "fr"},
+                            "news_coverage_status": {"label": "On Merit"},
+                        }
+                    ],
+                    "event_item": event_1_id,
+                },
+                {
+                    "_id": planning_3_id,
+                    "type": "planning",
+                    "slugline": "planning-picture",
+                    "description_text": "Planning for picture coverage",
+                    "dates": bilingual_events[0]["dates"],
+                    "coverages": [
+                        {
+                            "coverage_id": "cov3",
+                            "planning": {"g2_content_type": "picture"},
+                            "news_coverage_status": {"label": "Planned"},
+                        }
+                    ],
+                    "event_item": event_1_id,
+                },
+                {
+                    "_id": planning_4_id,
+                    "type": "planning",
+                    "slugline": "planning-all-day-text",
+                    "description_text": "Planning for all-day event",
+                    "dates": bilingual_events[1]["dates"],
+                    "coverages": [
+                        {
+                            "coverage_id": "cov4",
+                            "planning": {"g2_content_type": "text", "language": "nl"},
+                            "news_coverage_status": {"label": "Planned"},
+                        }
+                    ],
+                    "event_item": event_2_id,
+                },
+                {
+                    "_id": planning_5_id,
+                    "type": "planning",
+                    "slugline": "planning-single-event",
+                    "description_text": "Planning for single language event",
+                    "dates": bilingual_events[2]["dates"],
+                    "coverages": [
+                        {
+                            "coverage_id": "cov5",
+                            "planning": {"g2_content_type": "text", "language": "nl"},
+                            "news_coverage_status": {"label": "Planned"},
+                        },
+                        {
+                            "coverage_id": "cov6",
+                            "planning": {"g2_content_type": "video"},
+                            "news_coverage_status": {"label": "On Merit"},
+                        },
+                    ],
+                    "event_item": event_3_id,
+                },
+            ]
+
+            self.app.data.insert("planning", planning_items)
+
+            self.app.data.update(
+                "events",
+                event_1_id,
+                {"planning_ids": [planning_1_id, planning_2_id, planning_3_id]},
+                bilingual_events[0],
+            )
+
+            self.app.data.update(
+                "events",
+                event_2_id,
+                {"planning_ids": [planning_4_id]},
+                bilingual_events[1],
+            )
+
+            self.app.data.update(
+                "events",
+                event_3_id,
+                {"planning_ids": [planning_5_id]},
+                bilingual_events[2],
+            )
+
+            bilingual_data = render_template(
+                "bilingual_news_events_tommorrow.html",
+                items=bilingual_events,
+                app=self.app,
+            )
+
+            self.assertIn(
+                "<h2>Dit is de Belga-agenda van de Belgische en internationale gebeurtenissen",
+                bilingual_data,
+                "Dutch introduction should be present",
+            )
+            self.assertIn(
+                "<h2>Voici l'agenda Belga des événements belges et internationaux",
+                bilingual_data,
+                "French introduction should be present",
+            )
+
+            self.assertIn(
+                "<h3>General</h3>",
+                bilingual_data,
+                "General calendar section should be present",
+            )
+            self.assertIn(
+                "<h3>Politics</h3>",
+                bilingual_data,
+                "Politics calendar section should be present",
+            )
+            self.assertIn(
+                "<h3>Economy</h3>",
+                bilingual_data,
+                "Economy calendar section should be present",
+            )
+
+            self.assertIn(
+                "<p>Test Event NL</p>", bilingual_data, "Dutch title should be present"
+            )
+            self.assertIn(
+                "<p>Test Event FR</p>", bilingual_data, "French title should be present"
+            )
+            self.assertIn(
+                "<p>Dutch description of the event</p>",
+                bilingual_data,
+                "Dutch description should be present",
+            )
+            self.assertIn(
+                "<p>French description of the event</p>",
+                bilingual_data,
+                "French description should be present",
+            )
+
+            self.assertIn(
+                "<p>All Day Event NL</p>",
+                bilingual_data,
+                "All-day Dutch title should be present",
+            )
+            self.assertIn(
+                "<p>All Day Event FR</p>",
+                bilingual_data,
+                "All-day French title should be present",
+            )
+            self.assertNotIn(
+                "00:00 - 23:59",
+                bilingual_data,
+                "All-day events should not show 00:00-23:59 time",
+            )
+
+            self.assertIn(
+                "11:00 - 19:00",
+                bilingual_data,
+                "Regular events should show specific time range",
+            )
+            self.assertIn(
+                "16:00 - 18:00",
+                bilingual_data,
+                "Afternoon events should show correct time range",
+            )
+
+            self.assertIn(
+                "Test Org - John Doe - Media Contact - jdoe@test.org - 123456789 - 987654321 - test.org",
+                bilingual_data,
+                "Contact information should be present",
+            )
+
+            self.assertIn(
+                "Brussels, Belgium",
+                bilingual_data,
+                "Location information should be present",
+            )
+            self.assertIn(
+                "Antwerp, Belgium",
+                bilingual_data,
+                "Second location should be present",
+            )
+
+            self.assertIn(
+                'href="http://test-event.com"',
+                bilingual_data,
+                "Event links should be present",
+            )
+            self.assertIn(
+                'href="http://allday-event.com"',
+                bilingual_data,
+                "All-day event links should be present",
+            )
+
+            general_index = bilingual_data.find("<h3>General</h3>")
+            politics_index = bilingual_data.find("<h3>Politics</h3>")
+            economy_index = bilingual_data.find("<h3>Economy</h3>")
+
+            self.assertLess(
+                general_index, politics_index, "General should come before Politics"
+            )
+            self.assertLess(
+                politics_index, economy_index, "Politics should come before Economy"
+            )
+
+            politics_section = bilingual_data.split("<h3>Politics</h3>")[1].split(
+                "<h3>"
+            )[0]
+            self.assertNotIn(
+                "00:00 - 23:59",
+                politics_section,
+                "All-day event should not show time",
+            )

--- a/server/tests/planning_export/planning_export_tests.py
+++ b/server/tests/planning_export/planning_export_tests.py
@@ -884,6 +884,17 @@ class PlanningExportTests(TestCase):
                 "website": "test.org",
             }
             self.app.data.insert("contacts", [test_contact])
+            desk_nl = ObjectId()
+            desk_fr = ObjectId()
+
+            test_desks = [
+                {"_id": desk_nl, "desk_language": "nl", "name": "Test Desk NL"},
+                {"_id": desk_fr, "desk_language": "fr", "name": "Test Desk FR"},
+            ]
+            self.app.data.remove(
+                "desks", {"name": {"$in": ["Test Desk NL", "Test Desk FR"]}}
+            )
+            self.app.data.insert("desks", test_desks)
 
             event_1_id = ObjectId()
             event_2_id = ObjectId()
@@ -964,7 +975,10 @@ class PlanningExportTests(TestCase):
                     "coverages": [
                         {
                             "coverage_id": "cov1",
-                            "planning": {"g2_content_type": "text", "language": "nl"},
+                            "planning": {
+                                "g2_content_type": "text",
+                                "desk": desk_nl,
+                            },
                             "news_coverage_status": {"label": "Planned"},
                         }
                     ],
@@ -979,7 +993,10 @@ class PlanningExportTests(TestCase):
                     "coverages": [
                         {
                             "coverage_id": "cov1",
-                            "planning": {"g2_content_type": "text", "language": "fr"},
+                            "planning": {
+                                "g2_content_type": "text",
+                                "desk": desk_fr,
+                            },
                             "news_coverage_status": {"label": "On Merit"},
                         }
                     ],
@@ -994,9 +1011,7 @@ class PlanningExportTests(TestCase):
                     "coverages": [
                         {
                             "coverage_id": "cov2",
-                            "planning": {
-                                "g2_content_type": "picture",
-                            },
+                            "planning": {"g2_content_type": "picture"},
                             "news_coverage_status": {"label": "Planned"},
                         }
                     ],
@@ -1011,7 +1026,10 @@ class PlanningExportTests(TestCase):
                     "coverages": [
                         {
                             "coverage_id": "cov2",
-                            "planning": {"g2_content_type": "text", "language": "nl"},
+                            "planning": {
+                                "g2_content_type": "text",
+                                "desk": desk_nl,
+                            },
                             "news_coverage_status": {"label": "Planned"},
                         }
                     ],
@@ -1156,6 +1174,16 @@ class PlanningExportTests(TestCase):
                 "website": "test.org",
             }
             self.app.data.insert("contacts", [test_contact])
+            desk_nl = ObjectId()
+            desk_fr = ObjectId()
+            test_desks = [
+                {"_id": desk_nl, "desk_language": "nl", "name": "Test Desk NL"},
+                {"_id": desk_fr, "desk_language": "fr", "name": "Test Desk FR"},
+            ]
+            self.app.data.remove(
+                "desks", {"name": {"$in": ["Test Desk NL", "Test Desk FR"]}}
+            )
+            self.app.data.insert("desks", test_desks)
 
             event_1_id = ObjectId()
             event_2_id = ObjectId()
@@ -1275,7 +1303,10 @@ class PlanningExportTests(TestCase):
                     "coverages": [
                         {
                             "coverage_id": "cov1",
-                            "planning": {"g2_content_type": "text", "language": "nl"},
+                            "planning": {
+                                "g2_content_type": "text",
+                                "desk": desk_nl,
+                            },
                             "news_coverage_status": {"label": "Planned"},
                         }
                     ],
@@ -1290,7 +1321,10 @@ class PlanningExportTests(TestCase):
                     "coverages": [
                         {
                             "coverage_id": "cov2",
-                            "planning": {"g2_content_type": "text", "language": "fr"},
+                            "planning": {
+                                "g2_content_type": "text",
+                                "desk": desk_fr,
+                            },
                             "news_coverage_status": {"label": "On Merit"},
                         }
                     ],
@@ -1320,7 +1354,10 @@ class PlanningExportTests(TestCase):
                     "coverages": [
                         {
                             "coverage_id": "cov4",
-                            "planning": {"g2_content_type": "text", "language": "nl"},
+                            "planning": {
+                                "g2_content_type": "text",
+                                "desk": desk_nl,
+                            },
                             "news_coverage_status": {"label": "Planned"},
                         }
                     ],
@@ -1335,7 +1372,10 @@ class PlanningExportTests(TestCase):
                     "coverages": [
                         {
                             "coverage_id": "cov5",
-                            "planning": {"g2_content_type": "text", "language": "nl"},
+                            "planning": {
+                                "g2_content_type": "text",
+                                "desk": desk_nl,
+                            },
                             "news_coverage_status": {"label": "Planned"},
                         },
                         {


### PR DESCRIPTION
Add formatting for `event items` in tomorrow’s bilingual advisory. `Events` are now displayed in both Dutch and French, with correct handling of coverages, calendar categorization, and both all-day and timed events.