### PR TITLE
Daily program in two languages for the Event and Planning advisories - For internal use [SDBELGA-990]

### DIFF
--- a/server/belga/planning_exports/internal_bilingual_events_advisory_tomorrow.py
+++ b/server/belga/planning_exports/internal_bilingual_events_advisory_tomorrow.py
@@ -1,39 +1,125 @@
-from .format_news_events_tommorow_bilingual import (
-    format_event_for_tommorow_bilingual as format_daily_bilingual,
+from .common import (
+    set_metadata,
+    get_subjects,
+    get_formatted_contacts,
+    get_item_location,
+    set_event_translations_value,
 )
 from typing import List, Dict, Any
+from superdesk.utc import utc_to_local
 from superdesk import get_resource_service
+
+CALENDAR_ORDER = [
+    "General",
+    "Politics",
+    "Economy",
+    "Regional",
+    "Justice",
+    "International",
+    "Sports",
+    "Culture",
+]
 
 
 def format_event_for_tommorow_bilingual_internal(
     event_data: List[Dict[str, Any]], locale: str
 ) -> Dict[str, Any]:
-    """
-    Reuse the daily bilingual formatting for general event info,
-    but replace coverages with internal-specific coverage logic
-    """
-    # # Get the daily program event formatte
-    base_formatted = format_daily_bilingual(event_data, locale)
+    """Format events into bilingual event list for advisory output"""
+    events_list: List[Dict[str, Any]] = []
+    calendar_groups: Dict[str, List[Dict[str, Any]]] = {}
 
-    # Replace coverages with internal coverage info
-    for day_group in base_formatted["events"]:
-        for event in day_group["events"]:
-            # The event dictionary contains all original fields
-            # Find the original event by title (or slugline)
-            original_event = next(
-                (
-                    e
-                    for e in event_data
-                    if (e.get("name") or e.get("slugline"))
-                    in (event["title_nl"], event["title_fr"])
-                ),
-                None,
+    # Determine weekday and date from the event
+    if event_data:
+        first_event_start = utc_to_local(
+            event_data[0]["dates"].get("tz", "Europe/Brussels"),
+            event_data[0]["dates"]["start"],
+        )
+        weekday_date = first_event_start.strftime("%A %d %B %Y").upper()
+    else:
+        weekday_date = ""
+
+    # Process events for both languages
+    for event in event_data:
+        # Get Dutch version
+        event_nl = event.copy()
+        set_event_translations_value(event_nl, "nl")
+
+        # Get French version
+        event_fr = event.copy()
+        set_event_translations_value(event_fr, "fr")
+
+        calendar = (
+            event["calendars"][0]["qcode"].capitalize()
+            if event.get("calendars")
+            else "Overig / Divers"
+        )
+
+        formatted_event = {
+            "subject": ",".join(get_subjects(event, "nl")),
+            "calendar": calendar,
+            "contacts": get_formatted_contacts(event),
+            "coverages": get_coverages_bilingual_internal(event),
+            "location": get_item_location(event, "nl"),
+            "title_nl": event_nl.get("name") or event_nl.get("slugline") or "",
+            "title_fr": event_fr.get("name") or event_fr.get("slugline") or "",
+            "description_nl": (
+                event_nl.get("definition_long")
+                or event_nl.get("description_text")
+                or event_nl.get("definition_short")
+                or ""
+            ).rstrip(),
+            "description_fr": (
+                event_fr.get("definition_long")
+                or event_fr.get("description_text")
+                or event_fr.get("definition_short")
+                or ""
+            ).rstrip(),
+        }
+
+        # Set metadata (links, etc.)
+        set_metadata(formatted_event, event, locale)
+
+        # Set dates and handle all-day events
+        dates = event["dates"]
+        tz = dates.get("tz") or "Europe/Brussels"
+        start_local = utc_to_local(tz, dates["start"])
+        end_local = utc_to_local(tz, dates["end"])
+
+        # Check if this is an all-day event (00:00-23:59)
+        is_all_day = (
+            start_local.hour == 0
+            and start_local.minute == 0
+            and end_local.hour == 23
+            and end_local.minute == 59
+        )
+
+        if is_all_day:
+            # For all-day events, don't show the time range
+            formatted_event["time"] = ""
+        else:
+            # Show specific time range
+            formatted_event["time"] = (
+                f"{start_local.strftime('%H:%M')} - {end_local.strftime('%H:%M')}"
             )
-            if original_event:
-                # Use internal coverage logic
-                event["coverages"] = get_coverages_bilingual_internal(original_event)
 
-    return base_formatted
+        calendar_groups.setdefault(calendar, []).append(formatted_event)
+
+    # Sort and merge by CALENDAR_ORDER
+    for calendar in CALENDAR_ORDER + sorted(
+        [c for c in calendar_groups if c not in CALENDAR_ORDER]
+    ):
+        if calendar in calendar_groups:
+            # Sort events: timed events first, then all-day events
+            events_sorted = sorted(
+                calendar_groups[calendar],
+                key=lambda x: (
+                    x["time"] == "",
+                    x["time"],
+                ),  # Empty time (all-day) goes last
+            )
+            events_list.append({"calendar": calendar, "events": events_sorted})
+
+    return {"weekday_date": weekday_date, "events": events_list}
 
 
 def get_coverages_bilingual_internal(event: Dict[str, Any]) -> List[Dict[str, Any]]:
@@ -74,9 +160,10 @@ def get_coverages_bilingual_internal(event: Dict[str, Any]) -> List[Dict[str, An
                 user_item = user_service.find_one(req=None, _id=assigned_user_id)
                 if user_item:
                     username = user_item.get("sign_off") or user_item.get("username")
-            elif desk_id:
+            if desk_id:
                 desk_item = desk_service.find_one(req=None, _id=desk_id)
                 if desk_item:
+                    desk_name = desk_item.get("name", "")
                     lang = desk_item.get("desk_language")
                     if lang:
                         lang = lang.lower()
@@ -87,24 +174,17 @@ def get_coverages_bilingual_internal(event: Dict[str, Any]) -> List[Dict[str, An
                         else:
                             desk_language_code = "N"
 
-                    # if no assigned user, take first member’s sign_off
-                    if desk_item.get("members"):
-                        first_member = desk_item["members"][0]
-                        user_item = user_service.find_one(
-                            req=None, _id=first_member["user"]
-                        )
-                        if user_item:
-                            username = user_item.get("sign_off") or user_item.get(
-                                "username"
-                            )
-
             if cov_type == "text":
                 coverage_display = f"TEXT {desk_language_code} ({cov_status})"
             else:
                 coverage_display = f"{cov_type.upper()} ({cov_status})"
 
+            # Add assigned user or desk name
             if username:
                 coverage_display = f"{coverage_display} BY {username.upper()}"
+            elif desk_name:
+                # When no user assigned, show full desk name only
+                coverage_display = f"{coverage_display} BY {desk_name.upper()}"
 
             formatted_coverages.append(
                 {
@@ -113,6 +193,7 @@ def get_coverages_bilingual_internal(event: Dict[str, Any]) -> List[Dict[str, An
                     "status": cov_status,
                     "language": desk_language_code,
                     "username": username,
+                    "desk_name": desk_name,
                 }
             )
 

--- a/server/belga/planning_exports/internal_bilingual_planning_advisory_tomorrow.py
+++ b/server/belga/planning_exports/internal_bilingual_planning_advisory_tomorrow.py
@@ -1,51 +1,136 @@
-from .format_planning_for_tomorrow_bilingual import (
-    format_planning_for_tomorrow_bilingual as format_public_planning,
+from .common import (
+    get_subjects,
+    get_formatted_contacts,
+    get_item_location,
+    set_event_translations_value,
 )
 from typing import List, Dict, Any
+from superdesk.utc import utc_to_local
 from superdesk import get_resource_service
+
+CALENDAR_ORDER = [
+    "General",
+    "Politics",
+    "Economy",
+    "Regional",
+    "Justice",
+    "International",
+    "Sports",
+    "Culture",
+]
 
 
 def format_planning_for_tomorrow_bilingual_internal(
     planning_data: List[Dict[str, Any]],
 ) -> Dict[str, Any]:
-    """
-    Reuse the bilingual planning formatter for general info,
-    but replace coverages with internal-specific coverage logic.
-    """
-    # Get the daily program planning formatte
-    base_formatted = format_public_planning(planning_data)
+    """Format planning items into bilingual advisory output"""
+    events_list: List[Dict[str, Any]] = []
+    calendar_groups: Dict[str, List[Dict[str, Any]]] = {}
 
     planning_service = get_resource_service("planning")
     desk_service = get_resource_service("desks")
-    user_service = get_resource_service("users")
+    event_service = get_resource_service("events")
 
-    # Replace coverages with internal logic
-    for calendar_group in base_formatted["events"]:
-        for planning in calendar_group["events"]:
-            # Find the original planning item
-            original = next(
-                (
-                    p
-                    for p in planning_data
-                    if (p.get("name") or p.get("slugline") or p.get("headline"))
-                    in (planning["title_nl"], planning["title_fr"])
-                ),
-                None,
+    # weekday and date
+    weekday_date = ""
+    if planning_data:
+        first_planning = planning_data[0]
+        weekday_date = get_advisory_weekday_date(
+            first_planning,
+            planning_service=planning_service,
+            event_service=event_service,
+        )
+
+    # Process each planning
+    for planning in planning_data:
+        # Fetch linked event
+        event_item = None
+        event_links = []
+        if planning.get("event_item"):
+            event_item = event_service.find_one(req=None, _id=planning["event_item"])
+            if event_item:
+                event_links = event_item.get("links", [])
+
+        # Calendar
+        calendar = "Overig / Divers"
+        if event_item and event_item.get("calendars"):
+            calendar = event_item["calendars"][0]["qcode"].capitalize()
+
+        # Set translations
+        planning_nl = planning.copy()
+        set_event_translations_value(planning_nl, "nl")
+        planning_fr = planning.copy()
+        set_event_translations_value(planning_fr, "fr")
+
+        # Contacts
+        contacts = (
+            get_formatted_contacts(event_item)
+            if event_item
+            else get_formatted_contacts(planning)
+        )
+
+        # Location
+        location = (
+            get_item_location(event_item, "nl")
+            if event_item
+            else get_item_location(planning, "nl")
+        )
+
+        # Format item
+        formatted_planning = {
+            "subject": ",".join(get_subjects(planning, "nl")),
+            "calendar": calendar,
+            "contacts": contacts,
+            "coverages": get_coverages_bilingual_internal(
+                planning, planning_service, desk_service
+            ),
+            "location": location,
+            "links": event_links,
+            "title_nl": planning.get("name")
+            or planning.get("slugline")
+            or planning.get("headline")
+            or "",
+            "title_fr": planning.get("name")
+            or planning.get("slugline")
+            or planning.get("headline")
+            or "",
+            "description_nl": (planning_nl.get("description_text") or "").rstrip(),
+            "description_fr": (planning_fr.get("description_text") or "").rstrip(),
+            "time": "",
+        }
+
+        # Set time from first coverage or planning date
+        scheduled = planning.get("planning_date")
+        coverages = planning.get("coverages", [])
+        if coverages and isinstance(coverages[0], dict):
+            scheduled = coverages[0].get("planning", {}).get("scheduled", scheduled)
+        if scheduled:
+            tz = "Europe/Brussels"
+            start_local = utc_to_local(tz, scheduled)
+            formatted_planning["time"] = start_local.strftime("%H:%M")
+
+        calendar_groups.setdefault(calendar, []).append(formatted_planning)
+
+    # Merge and sort by CALENDAR_ORDER
+    for calendar in CALENDAR_ORDER + sorted(
+        [c for c in calendar_groups if c not in CALENDAR_ORDER]
+    ):
+        if calendar in calendar_groups:
+            events_sorted = sorted(
+                calendar_groups[calendar], key=lambda x: (x["time"] == "", x["time"])
             )
-            if original:
-                planning["coverages"] = get_coverages_bilingual_internal(
-                    original, planning_service, desk_service, user_service
-                )
+            events_list.append({"calendar": calendar, "events": events_sorted})
 
-    return base_formatted
+    return {"weekday_date": weekday_date, "events": events_list}
 
 
 def get_coverages_bilingual_internal(
-    item: Dict[str, Any], planning_service, desk_service, user_service
+    item: Dict[str, Any], planning_service, desk_service
 ) -> List[Dict[str, Any]]:
-    """Get coverage info with proper status, language and assigned user for export"""
+    """Get coverage info with proper status and language for export"""
+    user_service = get_resource_service("users")
     formatted_coverages = []
-    lang_map = {"nl": "N", "n": "N", "fr": "F", "f": "F", "de": "DE"}
+    lang_map = {"nl": "N", "n": "N", "fr": "F", "f": "F", "de": "N"}
 
     planning_ids = item.get("planning_ids") or [item.get("_id")]
 
@@ -88,22 +173,16 @@ def get_coverages_bilingual_internal(
                 if user_item:
                     username = user_item.get("sign_off") or user_item.get("username")
 
-            elif desk_id:
+            if desk_id:
                 desk_item = desk_service.find_one(req=None, _id=desk_id)
-                if desk_item and desk_item.get("desk_language"):
-                    desk_language_code = lang_map.get(
-                        desk_item["desk_language"].lower(), "N"
-                    )
-                    # first member’s sign_off as fallback
-                    if desk_item.get("members"):
-                        first_member = desk_item["members"][0]
-                        user_item = user_service.find_one(
-                            req=None, _id=first_member["user"]
+                if desk_item:
+                    # Get desk name for display
+                    desk_name = desk_item.get("name", "")
+
+                    if desk_item and desk_item.get("desk_language"):
+                        desk_language_code = lang_map.get(
+                            desk_item["desk_language"].lower(), "N"
                         )
-                        if user_item:
-                            username = user_item.get("sign_off") or user_item.get(
-                                "username"
-                            )
 
             # Format coverage display
             if cov_type == "text":
@@ -111,8 +190,12 @@ def get_coverages_bilingual_internal(
             else:
                 coverage_display = f"{cov_type.upper()} ({cov_status})"
 
+            # Add assigned user or desk name
             if username:
                 coverage_display = f"{coverage_display} BY {username.upper()}"
+            elif desk_name:
+                # When no user assigned, show full desk name only
+                coverage_display = f"{coverage_display} BY {desk_name.upper()}"
 
             formatted_coverages.append(
                 {
@@ -121,7 +204,44 @@ def get_coverages_bilingual_internal(
                     "status": cov_status,
                     "language": desk_language_code,
                     "username": username,
+                    "desk_name": desk_name,
                 }
             )
 
     return formatted_coverages
+
+
+def get_advisory_weekday_date(planning_item, planning_service=None, event_service=None):
+    """Get weekday/date of planning, preferring linked event date"""
+    # If planning has linked event, use event start date
+    event_item = None
+    if event_service and planning_item.get("event_item"):
+        event_item = event_service.find_one(req=None, _id=planning_item["event_item"])
+        if event_item and event_item.get("dates") and event_item["dates"].get("start"):
+            tz = event_item["dates"].get("tz", "Europe/Brussels")
+            local_dt = utc_to_local(tz, event_item["dates"]["start"])
+            return local_dt.strftime("%A %d %B %Y").upper()
+
+    # Otherwise, fallback to scheduled in coverages or planning_date
+    if planning_service:
+        planning_item = planning_service.find_one(req=None, _id=planning_item["_id"])
+
+    coverages = planning_item.get("coverages", [])
+    scheduled = None
+
+    # Find scheduled from coverage
+    for cov in coverages:
+        if isinstance(cov, dict):
+            scheduled = cov.get("planning", {}).get("scheduled")
+            if scheduled:
+                break
+
+    # Fallback to planning_date
+    if not scheduled:
+        scheduled = planning_item.get("planning_date")
+
+    if scheduled:
+        local_dt = utc_to_local("Europe/Brussels", scheduled)
+        return local_dt.strftime("%A %d %B %Y").upper()
+
+    return ""

--- a/server/tests/planning_export/planning_export_tests.py
+++ b/server/tests/planning_export/planning_export_tests.py
@@ -1384,7 +1384,7 @@ class PlanningExportTests(TestCase):
             )
 
     def test_internal_bilingual_events_advisory_export_tomorrow(self):
-        """Test the internal bilingual events advisory template with usernames"""
+        """Test the internal bilingual events advisory template with usernames and full desk names"""
         with self.app.app_context():
             user_nl_id = ObjectId()
             user_fr_id = ObjectId()
@@ -1612,19 +1612,19 @@ class PlanningExportTests(TestCase):
             )
 
             self.assertIn(
-                "<p>TEXT N (PLANNED) BY RNL</p>",
+                f"<p>TEXT N (PLANNED) BY TEST DESK NL {timestamp}</p>",
                 internal_data,
-                "Dutch text coverage should show username from desk member",
+                "Dutch text coverage should show full desk name in UPPERCASE when no direct user",
             )
             self.assertIn(
-                "<p>TEXT F (ON MERIT) BY RFR</p>",
+                f"<p>TEXT F (ON MERIT) BY TEST DESK FR {timestamp}</p>",
                 internal_data,
-                "French text coverage should show username from desk member",
+                "French text coverage should show full desk name in UPPERCASE when no direct user",
             )
             self.assertIn(
-                "<p>PICTURE (PLANNED) BY PHOTO</p>",
+                f"<p>PICTURE (PLANNED) BY PICTURE DESK {timestamp}</p>",
                 internal_data,
-                "Picture coverage should show username from desk member",
+                "Picture coverage should show full desk name in UPPERCASE when no direct user",
             )
             self.assertIn(
                 "<p>TEXT N (PLANNED) BY RNL</p>",
@@ -1649,7 +1649,7 @@ class PlanningExportTests(TestCase):
             )
 
     def test_internal_bilingual_planning_advisory_export_tomorrow(self):
-        """Test the internal bilingual planning advisory template with usernames"""
+        """Test the internal bilingual planning advisory template with usernames and desk names"""
         with self.app.app_context():
             user_nl_id = ObjectId()
             user_fr_id = ObjectId()
@@ -1796,19 +1796,19 @@ class PlanningExportTests(TestCase):
             )
 
             self.assertIn(
-                "<p>TEXT N (PLANNED) BY PNL</p>",
+                f"<p>TEXT N (PLANNED) BY PLANNING DESK NL {timestamp}</p>",
                 internal_data,
-                "Dutch text coverage should show username from desk member",
+                "Dutch text coverage should show full desk name in UPPERCASE when no direct user",
             )
             self.assertIn(
-                "<p>TEXT F (ON MERIT) BY PFR</p>",
+                f"<p>TEXT F (ON MERIT) BY PLANNING DESK FR {timestamp}</p>",
                 internal_data,
-                "French text coverage should show username from desk member",
+                "French text coverage should show full desk name in UPPERCASE when no direct user",
             )
             self.assertIn(
-                "<p>PICTURE (PLANNED) BY PNL</p>",
+                f"<p>PICTURE (PLANNED) BY PLANNING DESK NL {timestamp}</p>",
                 internal_data,
-                "Picture coverage should show username from desk member",
+                "Picture coverage should show full desk name in UPPERCASE when no direct user",
             )
             self.assertIn(
                 "<p>VIDEO (PLANNED) BY VIDEO</p>",


### PR DESCRIPTION
Updated internal bilingual coverage logic to display the full desk name when no user is directly assigned and fixed the coverage desk language issue.