### PR TITLE
[SDBELGA-1000] fix(ingests): Convert Planning datetime to utc where tz not defined

### DIFF
--- a/server/belga/io/feed_parsers/belga_planning_ml.py
+++ b/server/belga/io/feed_parsers/belga_planning_ml.py
@@ -14,11 +14,15 @@ class BelgaPlanningMLParser(PlanningMLParser):
 
     def datetime(self, string):
         try:
-            return datetime.datetime.strptime(string.strip(), "%Y-%m-%dT%H:%M:%S.000Z")
+            return datetime.datetime.strptime(string.strip(), "%Y-%m-%dT%H:%M:%S.000Z").replace(
+                tzinfo=datetime.timezone.utc
+            )
         except (ValueError, TypeError):
             pass
         try:
-            return datetime.datetime.strptime(string.strip(), "%Y-%m-%dT%H:%M:%SZ")
+            return datetime.datetime.strptime(string.strip(), "%Y-%m-%dT%H:%M:%SZ").replace(
+                tzinfo=datetime.timezone.utc
+            )
         except (ValueError, TypeError):
             pass
         try:

--- a/server/belga/io/feed_parsers/belga_planning_ml.py
+++ b/server/belga/io/feed_parsers/belga_planning_ml.py
@@ -14,15 +14,15 @@ class BelgaPlanningMLParser(PlanningMLParser):
 
     def datetime(self, string):
         try:
-            return datetime.datetime.strptime(string.strip(), "%Y-%m-%dT%H:%M:%S.000Z").replace(
-                tzinfo=datetime.timezone.utc
-            )
+            return datetime.datetime.strptime(
+                string.strip(), "%Y-%m-%dT%H:%M:%S.000Z"
+            ).replace(tzinfo=datetime.timezone.utc)
         except (ValueError, TypeError):
             pass
         try:
-            return datetime.datetime.strptime(string.strip(), "%Y-%m-%dT%H:%M:%SZ").replace(
-                tzinfo=datetime.timezone.utc
-            )
+            return datetime.datetime.strptime(
+                string.strip(), "%Y-%m-%dT%H:%M:%SZ"
+            ).replace(tzinfo=datetime.timezone.utc)
         except (ValueError, TypeError):
             pass
         try:


### PR DESCRIPTION
### Purpose
When ingesting Planning items with datetime in `%Y-%m-%dT%H:%M:%S.000Z` or `%Y-%m-%dT%H:%M:%SZ` format, the resulting datetime instance did not have a timezone applied, causing issues when comparing this instance to a timezone aware instance.

### What has changed
Set `utc` as the timezone

Resolves: [SDBELGA-1000](https://sofab.atlassian.net/browse/SDBELGA-1000)

[SDBELGA-1000]: https://sofab.atlassian.net/browse/SDBELGA-1000?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ