### PR TITLE
[SDBELGA-1058] - Picture and video planning advisories - change requests

### DIFF
--- a/server/belga/planning_exports/internal_belga_image_planning.py
+++ b/server/belga/planning_exports/internal_belga_image_planning.py
@@ -1,4 +1,5 @@
 from typing import List, Dict, Any
+import datetime
 from datetime import date
 from superdesk.utc import utc_to_local
 from superdesk import get_resource_service
@@ -91,6 +92,7 @@ def format_image_planning(
 
         event = {
             "calendar": calendar,
+            "scheduled": scheduled,
             "time": times.get("time", ""),
             "display_time": times.get("display_time", ""),
             "location": location,
@@ -128,17 +130,23 @@ def format_image_planning(
             "group_by_calendar": True,
         }
     else:
-        all_events = []
         for day in ordered_days:
             day_calendars = days[day]["calendars"]
+            all_day_events = []
             for cal in day_calendars:
-                all_events.extend(day_calendars[cal])
+                all_day_events.extend(day_calendars[cal])
+            all_day_events.sort(
+                key=lambda e: e.get("scheduled")
+                or datetime.datetime.max.replace(tzinfo=datetime.timezone.utc)
+            )
+            days[day]["events"] = all_day_events
         return {
             "title": build_title(
                 title_prefix,
                 [days[d]["label"] for d in ordered_days],
             ),
-            "events": all_events,
+            "days": days,
+            "ordered_days": ordered_days,
             "group_by_calendar": False,
         }
 
@@ -146,7 +154,6 @@ def format_image_planning(
 def get_filtered_coverages(item, planning_service, desk_service, allowed_types):
     user_service = get_resource_service("users")
     formatted = []
-    lang_map = {"nl": "N", "n": "N", "fr": "F", "f": "F"}
 
     planning_ids = item.get("planning_ids") or [item.get("_id")]
 
@@ -170,7 +177,6 @@ def get_filtered_coverages(item, planning_service, desk_service, allowed_types):
                 coverage.get("news_coverage_status", {}).get("label") or "ON MERIT"
             ).upper()
 
-            desk_language = "N"
             desk_name = ""
             username = ""
 
@@ -179,9 +185,6 @@ def get_filtered_coverages(item, planning_service, desk_service, allowed_types):
                 desk = desk_service.find_one(req=None, _id=desk_id)
                 if desk:
                     desk_name = desk.get("name", "")
-                    desk_language = lang_map.get(
-                        desk.get("desk_language", "").lower(), "N"
-                    )
 
             user_id = coverage.get("assigned_to", {}).get("user")
             if user_id:
@@ -194,10 +197,9 @@ def get_filtered_coverages(item, planning_service, desk_service, allowed_types):
             elif desk_name:
                 display = desk_name.upper()
             else:
-                display = ""
+                display = cov_status
 
-            if display:
-                formatted.append({"display": display})
+            formatted.append({"display": display})
 
     return formatted
 

--- a/server/belga/planning_exports/internal_belga_image_planning.py
+++ b/server/belga/planning_exports/internal_belga_image_planning.py
@@ -9,27 +9,19 @@ from .common import (
     set_event_translations_value,
     ADVISORY_TIMEZONE,
     format_advisory_weekday_date,
-    format_coverage_label,
     get_display_times,
     is_editorial_calendar,
 )
 
-CALENDAR_ORDER = [
-    "Sports",
-    "General",
-    "Politics",
-    "Economy",
-    "Regional",
-    "Justice",
-    "International",
-    "Culture",
-]
+CALENDAR_ORDER_PHOTO = ["Sports", "General"]
 
 
 def format_image_planning(
     planning_data: List[Dict[str, Any]],
     allowed_coverage_types: set,
     title_prefix: str,
+    group_by_calendar: bool = True,
+    sports_first: bool = False,
 ) -> Dict[str, Any]:
 
     planning_service = get_resource_service("planning")
@@ -52,6 +44,8 @@ def format_image_planning(
         calendar = ""
         if event_item and event_item.get("calendars"):
             calendar = event_item["calendars"][0]["qcode"].capitalize()
+            if sports_first and calendar != "Sports":
+                calendar = "General"
 
         planning_nl = planning.copy()
         planning_fr = planning.copy()
@@ -121,15 +115,32 @@ def format_image_planning(
 
     ordered_days = sorted(days.keys())
 
-    return {
-        "title": build_title(
-            title_prefix,
-            [days[d]["label"] for d in ordered_days],
-        ),
-        "days": days,
-        "ordered_days": ordered_days,
-        "calendar_order": CALENDAR_ORDER,
-    }
+    if group_by_calendar:
+        calendar_order = CALENDAR_ORDER_PHOTO if sports_first else None
+        return {
+            "title": build_title(
+                title_prefix,
+                [days[d]["label"] for d in ordered_days],
+            ),
+            "days": days,
+            "ordered_days": ordered_days,
+            "calendar_order": calendar_order,
+            "group_by_calendar": True,
+        }
+    else:
+        all_events = []
+        for day in ordered_days:
+            day_calendars = days[day]["calendars"]
+            for cal in day_calendars:
+                all_events.extend(day_calendars[cal])
+        return {
+            "title": build_title(
+                title_prefix,
+                [days[d]["label"] for d in ordered_days],
+            ),
+            "events": all_events,
+            "group_by_calendar": False,
+        }
 
 
 def get_filtered_coverages(item, planning_service, desk_service, allowed_types):
@@ -178,14 +189,15 @@ def get_filtered_coverages(item, planning_service, desk_service, allowed_types):
                 if user:
                     username = user.get("sign_off") or user.get("username")
 
-            display = format_coverage_label(cov_type, desk_language, cov_status)
-
             if username:
-                display = f"{display} BY {username.upper()}"
+                display = username.upper()
             elif desk_name:
-                display = f"{display} BY {desk_name.upper()}"
+                display = desk_name.upper()
+            else:
+                display = ""
 
-            formatted.append({"display": display})
+            if display:
+                formatted.append({"display": display})
 
     return formatted
 

--- a/server/belga/planning_exports/internal_image_photo_planning.py
+++ b/server/belga/planning_exports/internal_image_photo_planning.py
@@ -6,4 +6,6 @@ def format_internal_image_photo_planning(items):
         planning_data=items,
         allowed_coverage_types={"picture"},
         title_prefix="Belga Image Photo Planning",
+        group_by_calendar=True,
+        sports_first=True,
     )

--- a/server/belga/planning_exports/internal_image_video_planning.py
+++ b/server/belga/planning_exports/internal_image_video_planning.py
@@ -6,4 +6,5 @@ def format_internal_image_video_planning(items):
         planning_data=items,
         allowed_coverage_types={"video"},
         title_prefix="Belga Image Video Planning",
+        group_by_calendar=False,
     )

--- a/server/templates/internal_image_photo_planning.html
+++ b/server/templates/internal_image_photo_planning.html
@@ -15,33 +15,19 @@
                 {% if event.time %}<p>{{ event.time }}</p>{% endif %}
                 {% if event.location %}<p>{{ event.location }}</p>{% endif %}
 
-                {% if event.title_nl %}<p>{{ event.title_nl }}</p>{% endif %}
+                {% if event.title_nl %}<p><b>{{ event.title_nl }}</b></p>{% endif %}
                 {% if event.title_fr and event.title_fr != event.title_nl %}
-                    <p>{{ event.title_fr }}</p>
+                    <p><b>{{ event.title_fr }}</b></p>
                 {% endif %}
-
-                {% if event.description_nl %}<p>{{ event.description_nl }}</p>{% endif %}
-                {% if event.description_fr and event.description_fr != event.description_nl %}
-                    <p>{{ event.description_fr }}</p>{% endif %}
 
                 {% for link in event.links %}
                     <p><a href="{{ link }}">{{ link }}</a></p>
                 {% endfor %}
 
-                {% for contact in event.contacts %}
-                    <p>
-                        {{ contact.organisation }} - {{ contact.name }}
-                        - {{ contact.job_title }}
-                        - {{ contact.email|join(", ") }}
-                        - {{ contact.phone|join(", ") }}
-                        - {{ contact.mobile|join(", ") }}
-                        - {{ contact.website }}
-                    </p>
-                {% endfor %}
-
                 {% for cov in event.coverages %}
                     <p>{{ cov.display }}</p>
                 {% endfor %}
+                <br>
             {% endfor %}
         {% endif %}
     {% endfor %}

--- a/server/templates/internal_image_video_planning.html
+++ b/server/templates/internal_image_video_planning.html
@@ -2,47 +2,21 @@
 
 <h1>{{ data.title }}</h1>
 
-{% for day in data.ordered_days %}
-    <h2>{{ data.days[day].label }}</h2>
+{% for event in data.events %}
+    {% if event.time %}<p>{{ event.time }}</p>{% endif %}
+    {% if event.location %}<p>{{ event.location }}</p>{% endif %}
 
-    {% set calendars = data.days[day].calendars %}
+    {% if event.title_nl %}<p><b>{{ event.title_nl }}</b></p>{% endif %}
+    {% if event.title_fr and event.title_fr != event.title_nl %}
+        <p><b>{{ event.title_fr }}</b></p>
+    {% endif %}
 
-    {% for calendar in data.calendar_order %}
-        {% if calendar in calendars %}
-            <h3>{{ calendar }}</h3>
-
-            {% for event in calendars[calendar] %}
-                {% if event.time %}<p>{{ event.time }}</p>{% endif %}
-                {% if event.location %}<p>{{ event.location }}</p>{% endif %}
-
-                {% if event.title_nl %}<p>{{ event.title_nl }}</p>{% endif %}
-                {% if event.title_fr and event.title_fr != event.title_nl %}
-                    <p>{{ event.title_fr }}</p>
-                {% endif %}
-
-                {% if event.description_nl %}<p>{{ event.description_nl }}</p>{% endif %}
-                {% if event.description_fr and event.description_fr != event.description_nl %}
-                    <p>{{ event.description_fr }}</p>{% endif %}
-
-                {% for link in event.links %}
-                    <p><a href="{{ link }}">{{ link }}</a></p>
-                {% endfor %}
-
-                {% for contact in event.contacts %}
-                    <p>
-                        {{ contact.organisation }} - {{ contact.name }}
-                        - {{ contact.job_title }}
-                        - {{ contact.email|join(", ") }}
-                        - {{ contact.phone|join(", ") }}
-                        - {{ contact.mobile|join(", ") }}
-                        - {{ contact.website }}
-                    </p>
-                {% endfor %}
-
-                {% for cov in event.coverages %}
-                    <p>{{ cov.display }}</p>
-                {% endfor %}
-            {% endfor %}
-        {% endif %}
+    {% for link in event.links %}
+        <p><a href="{{ link }}">{{ link }}</a></p>
     {% endfor %}
+
+    {% for cov in event.coverages %}
+        <p>{{ cov.display }}</p>
+    {% endfor %}
+    <br>
 {% endfor %}

--- a/server/templates/internal_image_video_planning.html
+++ b/server/templates/internal_image_video_planning.html
@@ -2,21 +2,25 @@
 
 <h1>{{ data.title }}</h1>
 
-{% for event in data.events %}
-    {% if event.time %}<p>{{ event.time }}</p>{% endif %}
-    {% if event.location %}<p>{{ event.location }}</p>{% endif %}
+{% for day in data.ordered_days %}
+    <h2>{{ data.days[day].label }}</h2>
 
-    {% if event.title_nl %}<p><b>{{ event.title_nl }}</b></p>{% endif %}
-    {% if event.title_fr and event.title_fr != event.title_nl %}
-        <p><b>{{ event.title_fr }}</b></p>
-    {% endif %}
+    {% for event in data.days[day].events %}
+        {% if event.time %}<p>{{ event.time }}</p>{% endif %}
+        {% if event.location %}<p>{{ event.location }}</p>{% endif %}
 
-    {% for link in event.links %}
-        <p><a href="{{ link }}">{{ link }}</a></p>
+        {% if event.title_nl %}<p><b>{{ event.title_nl }}</b></p>{% endif %}
+        {% if event.title_fr and event.title_fr != event.title_nl %}
+            <p><b>{{ event.title_fr }}</b></p>
+        {% endif %}
+
+        {% for link in event.links %}
+            <p><a href="{{ link }}">{{ link }}</a></p>
+        {% endfor %}
+
+        {% for cov in event.coverages %}
+            <p>{{ cov.display }}</p>
+        {% endfor %}
+        <br>
     {% endfor %}
-
-    {% for cov in event.coverages %}
-        <p>{{ cov.display }}</p>
-    {% endfor %}
-    <br>
 {% endfor %}

--- a/server/tests/planning_export/planning_export_tests.py
+++ b/server/tests/planning_export/planning_export_tests.py
@@ -2243,6 +2243,14 @@ class PlanningExportTests(TestCase):
         with self.app.app_context():
             event_id = ObjectId()
             planning_id = ObjectId()
+            user_id = ObjectId()
+
+            user = {
+                "_id": user_id,
+                "username": f"testuser_photo_{user_id}",
+                "sign_off": "TST",
+            }
+            self.app.data.insert("users", [user])
 
             event = {
                 "_id": event_id,
@@ -2265,7 +2273,7 @@ class PlanningExportTests(TestCase):
                 "planning_date": datetime.datetime(
                     2026, 1, 9, 9, 0, tzinfo=datetime.timezone.utc
                 ),
-                "name": "Mixed coverage planning",
+                "name": "Sports Photo Event",
                 "description_text": "Planning description",
                 "coverages": [
                     {
@@ -2276,6 +2284,7 @@ class PlanningExportTests(TestCase):
                         "coverage_id": ObjectId(),
                         "planning": {"g2_content_type": "picture"},
                         "news_coverage_status": {"label": "Planned"},
+                        "assigned_to": {"user": user_id},
                     },
                     {
                         "coverage_id": ObjectId(),
@@ -2302,15 +2311,24 @@ class PlanningExportTests(TestCase):
             )
 
             self.assertIn("<h1>Belga Image Photo Planning", html)
-            self.assertIn("BELGA PICTURE (PLANNED)", html)
+            self.assertIn("<b>Sports Photo Event</b>", html)
             self.assertNotIn("TEXT", html)
             self.assertNotIn("VIDEO", html)
+            self.assertNotIn("BELGA PICTURE", html)
 
     def test_belga_image_video_planning_renders_video_only(self):
         """Belga Image Video Planning renders video coverage and excludes picture/text."""
         with self.app.app_context():
             event_id = ObjectId()
             planning_id = ObjectId()
+            user_id = ObjectId()
+
+            user = {
+                "_id": user_id,
+                "username": f"testuser_video_{user_id}",
+                "sign_off": "TST",
+            }
+            self.app.data.insert("users", [user])
 
             event = {
                 "_id": event_id,
@@ -2333,7 +2351,7 @@ class PlanningExportTests(TestCase):
                 "planning_date": datetime.datetime(
                     2026, 1, 10, 14, 0, tzinfo=datetime.timezone.utc
                 ),
-                "name": "Video planning",
+                "name": "Video Event",
                 "description_text": "Video planning description",
                 "coverages": [
                     {
@@ -2345,6 +2363,7 @@ class PlanningExportTests(TestCase):
                         "coverage_id": ObjectId(),
                         "planning": {"g2_content_type": "video"},
                         "news_coverage_status": {"label": "On Merit"},
+                        "assigned_to": {"user": user_id},
                     },
                 ],
                 "event_item": event_id,
@@ -2367,6 +2386,7 @@ class PlanningExportTests(TestCase):
             )
 
             self.assertIn("<h1>Belga Image Video Planning", html)
-            self.assertIn("BELGA VIDEO (ON MERIT)", html)
+            self.assertIn("<b>Video Event</b>", html)
             self.assertNotIn("PICTURE", html)
             self.assertNotIn("TEXT", html)
+            self.assertNotIn("BELGA VIDEO", html)

--- a/server/tests/planning_export/planning_export_tests.py
+++ b/server/tests/planning_export/planning_export_tests.py
@@ -2315,6 +2315,8 @@ class PlanningExportTests(TestCase):
             self.assertNotIn("TEXT", html)
             self.assertNotIn("VIDEO", html)
             self.assertNotIn("BELGA PICTURE", html)
+            self.assertIn(user["sign_off"], html)
+            self.assertNotIn(planning["description_text"], html)
 
     def test_belga_image_video_planning_renders_video_only(self):
         """Belga Image Video Planning renders video coverage and excludes picture/text."""
@@ -2390,3 +2392,116 @@ class PlanningExportTests(TestCase):
             self.assertNotIn("PICTURE", html)
             self.assertNotIn("TEXT", html)
             self.assertNotIn("BELGA VIDEO", html)
+            self.assertIn(user["sign_off"], html)
+            self.assertNotIn(planning["description_text"], html)
+
+    def test_belga_image_video_planning_chronological_order(self):
+        """Belga Image Video Planning lists events chronologically by day."""
+        with self.app.app_context():
+            user_id = ObjectId()
+
+            user = {
+                "_id": user_id,
+                "username": f"testuser_chrono_{user_id}",
+                "sign_off": "TST",
+            }
+            self.app.data.insert("users", [user])
+
+            event1_id = ObjectId()
+            planning1_id = ObjectId()
+            event2_id = ObjectId()
+            planning2_id = ObjectId()
+
+            event1 = {
+                "_id": event1_id,
+                "name": "Later Event",
+                "dates": {
+                    "start": datetime.datetime(
+                        2026, 1, 10, 16, 0, tzinfo=datetime.timezone.utc
+                    ),
+                    "end": datetime.datetime(
+                        2026, 1, 10, 18, 0, tzinfo=datetime.timezone.utc
+                    ),
+                    "tz": "Europe/Brussels",
+                },
+                "calendars": [{"qcode": "Sports", "name": "(7) Sports"}],
+            }
+
+            planning1 = {
+                "_id": planning1_id,
+                "type": "planning",
+                "planning_date": datetime.datetime(
+                    2026, 1, 10, 16, 0, tzinfo=datetime.timezone.utc
+                ),
+                "name": "Later Event",
+                "coverages": [
+                    {
+                        "coverage_id": ObjectId(),
+                        "planning": {"g2_content_type": "video"},
+                        "assigned_to": {"user": user_id},
+                    },
+                ],
+                "event_item": event1_id,
+            }
+
+            event2 = {
+                "_id": event2_id,
+                "name": "Earlier Event",
+                "dates": {
+                    "start": datetime.datetime(
+                        2026, 1, 10, 10, 0, tzinfo=datetime.timezone.utc
+                    ),
+                    "end": datetime.datetime(
+                        2026, 1, 10, 12, 0, tzinfo=datetime.timezone.utc
+                    ),
+                    "tz": "Europe/Brussels",
+                },
+                "calendars": [{"qcode": "General", "name": "(1) General"}],
+            }
+
+            planning2 = {
+                "_id": planning2_id,
+                "type": "planning",
+                "planning_date": datetime.datetime(
+                    2026, 1, 10, 10, 0, tzinfo=datetime.timezone.utc
+                ),
+                "name": "Earlier Event",
+                "coverages": [
+                    {
+                        "coverage_id": ObjectId(),
+                        "planning": {"g2_content_type": "video"},
+                        "assigned_to": {"user": user_id},
+                    },
+                ],
+                "event_item": event2_id,
+            }
+
+            self.app.data.insert("events", [event1, event2])
+            self.app.data.insert("planning", [planning1, planning2])
+
+            self.app.data.update(
+                "events",
+                event1_id,
+                {"planning_ids": [planning1_id]},
+                event1,
+            )
+            self.app.data.update(
+                "events",
+                event2_id,
+                {"planning_ids": [planning2_id]},
+                event2,
+            )
+
+            html = render_template(
+                "internal_image_video_planning.html",
+                items=[planning1, planning2],
+                app=self.app,
+            )
+
+            earlier_pos = html.find("<b>Earlier Event</b>")
+            later_pos = html.find("<b>Later Event</b>")
+            self.assertGreater(earlier_pos, -1, "Earlier Event should be in output")
+            self.assertGreater(later_pos, -1, "Later Event should be in output")
+            self.assertLess(
+                earlier_pos, later_pos, "Earlier Event should appear before Later Event"
+            )


### PR DESCRIPTION
This PR makes changes to Belga Image Photo Planning and Belga Image Video Planning custom layouts:

- Set event name in bold
- Remove description (both languages)
- Remove contacts (both languages)
- Add line break after each event for spacing
- Remove 'BELGA PICTURE (PLANNED) BY' and 'BELGA VIDEO (PLANNED) BY' prefixes (show username only)
- Photo Planning: SPORTS calendar first, then GENERAL section for all other events
- Video Planning: Remove calendar sections entirely, list events chronologically

Updated tests to reflect new expected output format.

Resolves: [SDBELGA-1058](https://sofab.atlassian.net/browse/SDBELGA-1058)

[SDBELGA-1058]: https://sofab.atlassian.net/browse/SDBELGA-1058?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ