### PR TITLE
Add PLANNING_EXPAND_RELATED_PLANNINGS setting

### DIFF
--- a/server/settings.py
+++ b/server/settings.py
@@ -365,3 +365,6 @@ ASSIGNMENT_MAIL_ICAL_USE_EVENT_DATES = True
 PLANNING_MANUAL_NEWS_COVERAGE_STATUS = True
 
 AMAZON_MEDIA_ID_TIME_PREFIX = "none"
+
+# It will expand/unfold Event's planning-related items in the Planning Combined view
+PLANNING_EXPAND_RELATED_PLANNINGS = True


### PR DESCRIPTION
Introduce PLANNING_EXPAND_RELATED_PLANNINGS in server/settings.py to enable expanding/unfolding Event's planning-related items in the Planning Combined view.

[SDBELGA-1076]

[SDBELGA-1076]: https://sofab.atlassian.net/browse/SDBELGA-1076?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ