### PR TITLE
[SDBELGA-1109] fix: add TBC handling to coverage due date strategy

### DIFF
--- a/client/index.tsx
+++ b/client/index.tsx
@@ -44,6 +44,11 @@ function getCoverageDueDate(
         coverageTime.set('hour', 20);
         coverageTime.set('minute', 0);
         coverageTime.set('second', 0);
+    } else if (eventItem && eventItem._time_to_be_confirmed) {
+        coverageTime = moment(eventItem.dates?.end);
+        coverageTime.set('hour', 20);
+        coverageTime.set('minute', 0);
+        coverageTime.set('second', 0);
     } else if (eventItem) {
         coverageTime = moment(eventItem.dates?.end);
         coverageTime.add(1, 'hour');


### PR DESCRIPTION
### Purpose
Add handling for TBC (time to be confirmed) events in the custom coverage due date strategy.

### What has changed
- Added a new condition for `_time_to_be_confirmed` events in the getCoverageDueDate function. TBC events now get the same treatment as all-day events: the due time is set to 20:00 (8pm) of the same day.

### Steps to test
1. Create an event with TBC time.
2. Add a planning item and coverage.
3. Verify the coverage due time is set to 20:00.


Note: This PR is linked to this [PR in superdesk-planning ](https://github.com/superdesk/superdesk-planning/pull/2870)
Resolves: #[SDBELGA-1109](https://sofab.atlassian.net/browse/SDBELGA-1109)

[SDBELGA-1109]: https://sofab.atlassian.net/browse/SDBELGA-1109?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ